### PR TITLE
Add tests for alphabet conversion helpers

### DIFF
--- a/test/alphabet_test.dart
+++ b/test/alphabet_test.dart
@@ -1,0 +1,22 @@
+import 'package:test/test.dart';
+import 'package:livnium_core/src/alphabet.dart';
+
+void main() {
+  group('alphabet helpers', () {
+    test('stringToDigits converts valid string', () {
+      expect(stringToDigits('0az'), equals([0, 1, 26]));
+    });
+
+    test('stringToDigits returns null on invalid character', () {
+      expect(stringToDigits('0a?'), isNull);
+    });
+
+    test('digitsToString converts digits', () {
+      expect(digitsToString([0, 1, 26]), equals('0az'));
+    });
+
+    test('digitsToString returns null on out-of-range digit', () {
+      expect(digitsToString([0, 27]), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add unit tests covering alphabet string and digit conversion helpers

## Testing
- `dart test` *(fails: bash: command not found: dart)*

------
https://chatgpt.com/codex/tasks/task_e_689524cee514832eb3a775afab7be87d