### PR TITLE
Label 9-scale energy helpers

### DIFF
--- a/example/energy_demo.dart
+++ b/example/energy_demo.dart
@@ -4,17 +4,17 @@ void main() {
   final glyphs = ['0', 'a', 'f', 'g', 'r', 's', 'z'];
   for (final ch in glyphs) {
     final f = facesForGlyph(ch);
-    final e = symbolEnergy(ch);
-    print('$ch  faces=$f  SE=$e');
+    final e9 = symbolEnergy9(ch);
+    print('$ch  faces=$f  SE9=$e9');
   }
   final words = ['a', 'gr', 'sz', 'livnium'];
   for (final w in words) {
-    print('$w  wordEnergy=${wordEnergy(w)}');
+    print('$w  wordEnergy9=${wordEnergy9(w)}');
   }
   print('K = $equilibriumConstant');
   print(
     'perFace: f1=${perFaceUnitEnergy(1)} f2=${perFaceUnitEnergy(2)} f3=${perFaceUnitEnergy(3)}',
   );
 
-  selfTestSymbolEnergy();
+  selfTestSymbolEnergy9();
 }

--- a/lib/livnium_core.dart
+++ b/lib/livnium_core.dart
@@ -36,8 +36,8 @@ export 'src/energy.dart'
     show
         SymbolClass,
         facesForGlyph,
-        symbolEnergy,
-        wordEnergy,
+        symbolEnergy9,
+        wordEnergy9,
         equilibriumConstant,
         perFaceUnitEnergy;
 

--- a/lib/src/energy.dart
+++ b/lib/src/energy.dart
@@ -59,24 +59,24 @@ double perFaceUnitEnergy(int faces) {
   return equilibriumConstant / faces;
 }
 
-/// Symbol Energy (SE) by class:
-///   SE = (faces / 3) * 27
+/// Symbol Energy on the 9/18/27 scale.
+///   SE9 = (faces / 3) * 27
 /// So:
 ///   center (1 face) →  9
 ///   edge   (2 face) → 18
 ///   corner (3 face) → 27
 /// core (0 face) gets 0 by definition here.
-double? symbolEnergy(String ch) {
+double? symbolEnergy9(String ch) {
   final f = facesForGlyph(ch);
   if (f < 0) return null; // invalid glyph
   return (f / 3.0) * 27.0;
 }
 
 /// Sum energy across a word; returns 0 if any glyph is invalid.
-double? wordEnergy(String word) {
+double? wordEnergy9(String word) {
   double total = 0;
   for (final ch in word.split('')) {
-    final e = symbolEnergy(ch);
+    final e = symbolEnergy9(ch);
     if (e == null) return null;
     total += e;
   }
@@ -84,7 +84,7 @@ double? wordEnergy(String word) {
 }
 
 /// Optional: quick invariants + examples. Call in a demo/test target.
-void selfTestSymbolEnergy() {
+void selfTestSymbolEnergy9() {
   // Class boundaries
   assert(facesForGlyph('0') == 0);
   for (final ch in ['a', 'b', 'c', 'd', 'e', 'f']) {
@@ -102,7 +102,7 @@ void selfTestSymbolEnergy() {
     'o',
     'p',
     'q',
-    'r'
+    'r',
   ]) {
     assert(facesForGlyph(ch) == 2);
   }
@@ -111,11 +111,11 @@ void selfTestSymbolEnergy() {
   }
 
   // Energies match the stated rule.
-  assert(symbolEnergy('a') == 9.0);
-  assert(symbolEnergy('g') == 18.0);
-  assert(symbolEnergy('s') == 27.0);
-  assert(symbolEnergy('0') == 0.0);
-  assert(symbolEnergy('?') == null);
+  assert(symbolEnergy9('a') == 9.0);
+  assert(symbolEnergy9('g') == 18.0);
+  assert(symbolEnergy9('s') == 27.0);
+  assert(symbolEnergy9('0') == 0.0);
+  assert(symbolEnergy9('?') == null);
 
   // Per-face unit energy sanity
   assert(perFaceUnitEnergy(1) == 10.125);
@@ -123,8 +123,8 @@ void selfTestSymbolEnergy() {
   assert(perFaceUnitEnergy(3) == 3.375);
 
   // Word energy examples
-  assert(wordEnergy('a') == 9.0);
-  assert(wordEnergy('ag') == 27.0); // 9 + 18
-  assert(wordEnergy('as') == 36.0); // 9 + 27
-  assert(wordEnergy('a?') == null);
+  assert(wordEnergy9('a') == 9.0);
+  assert(wordEnergy9('ag') == 27.0); // 9 + 18
+  assert(wordEnergy9('as') == 36.0); // 9 + 27
+  assert(wordEnergy9('a?') == null);
 }

--- a/test/core_usage_test.dart
+++ b/test/core_usage_test.dart
@@ -16,7 +16,7 @@ void main() {
     });
 
     test('computes word energy', () {
-      expect(wordEnergy(word), equals(63.0));
+      expect(wordEnergy9(word), equals(63.0));
     });
 
     test('rotates a vector around the Z axis', () {


### PR DESCRIPTION
## Summary
- rename energy helpers to explicitly use the 9/18/27 scale (`symbolEnergy9`, `wordEnergy9`)
- export renamed helpers and update demo and test code

## Testing
- `dart format lib/src/energy.dart lib/livnium_core.dart example/energy_demo.dart test/core_usage_test.dart`
- `dart test` *(fails: quick start example rotates a vector around the Z axis)*
- `dart run example/energy_demo.dart`


------
https://chatgpt.com/codex/tasks/task_e_689cfe69a0c4832e9f62f36c5e5a3e71