### PR TITLE
Add coupler-aware Potts weight builder with geometry-aware tests

### DIFF
--- a/example/recall_demo.dart
+++ b/example/recall_demo.dart
@@ -1,0 +1,58 @@
+import 'package:livnium_core/livnium_core.dart';
+import 'package:livnium_core/src/potts.dart';
+
+void main() {
+  final patterns = [
+    List.generate(27, (i) => i % Potts27.q),
+    List.filled(27, 3),
+    List.generate(27, (i) => (i * 2) % Potts27.q),
+  ];
+
+  final netGeom = Potts27.cube();
+  netGeom.buildFromCouplers(
+    params: CouplerParams(tau0: 1, alpha: 1),
+    kernel: cosKernel,
+    targetNorm: 0.5,
+  );
+  netGeom.store(patterns, blend: 0.5);
+
+  final netFlat = Potts27.cube();
+  netFlat.buildFromCouplers(
+    params: CouplerParams(tau0: 1, alpha: 1),
+    kernel: cosKernel,
+    targetNorm: 0.5,
+    geoMix: 0,
+  );
+  netFlat.store(patterns, blend: 1.0);
+
+  final coords = cube3Coords().toList();
+  final target = patterns[0];
+  final noisy = List<int>.from(target);
+  for (var i = 0; i < coords.length; i++) {
+    if (coords[i].z == 1) {
+      noisy[i] = (noisy[i] + 1) % Potts27.q;
+    }
+  }
+
+  for (var i = 0; i < netGeom.n; i++) {
+    netGeom.s[i] = noisy[i];
+    netFlat.s[i] = noisy[i];
+  }
+
+  netGeom.relax();
+  netFlat.relax();
+
+  int correct(List<int> s) {
+    var c = 0;
+    for (var i = 0; i < target.length; i++) {
+      if (s[i] == target[i]) c++;
+    }
+    return c;
+  }
+
+  final geomCorrect = correct(netGeom.s);
+  final flatCorrect = correct(netFlat.s);
+
+  print('Geom correct: $geomCorrect / ${target.length}');
+  print('Flat correct: $flatCorrect / ${target.length}');
+}

--- a/lib/src/potts.dart
+++ b/lib/src/potts.dart
@@ -1,7 +1,18 @@
 library;
 
+import 'dart:math' as math;
+
 import 'grid.dart';
 import 'vec3.dart';
+import 'coupler.dart';
+
+typedef SimilarityKernel = double Function(int k, int l);
+
+double cosKernel(int k, int l) {
+  const twoPiOver27 = 2 * math.pi / 27.0;
+  final d = (k - l);
+  return math.cos(twoPiOver27 * d);
+}
 
 /// Simple Potts-Hopfield network with 27 possible symbols per node.
 class Potts27 {
@@ -25,10 +36,12 @@ class Potts27 {
   final List<int> s;
 
   Potts27(this.n, this.nbrs)
-      : w = List.generate(
-            n, (_) => List.generate(n, (_) => List.filled(q * q, 0.0))),
-        b = List.generate(n, (_) => List.filled(q, 0.0)),
-        s = List.filled(n, 0);
+    : w = List.generate(
+        n,
+        (_) => List.generate(n, (_) => List.filled(q * q, 0.0)),
+      ),
+      b = List.generate(n, (_) => List.filled(q, 0.0)),
+      s = List.filled(n, 0);
 
   /// Factory that builds a 3×3×3 cube (27 nodes) with 6-neighborhoods.
   factory Potts27.cube() {
@@ -46,10 +59,79 @@ class Potts27 {
     return Potts27(n, nbrs);
   }
 
+  void buildFromCouplers({
+    required CouplerParams params,
+    required SimilarityKernel kernel,
+    required double targetNorm,
+    double geoMix = 1.0,
+  }) {
+    for (var i = 0; i < n; i++) {
+      for (final j in nbrs[i]) {
+        final wij = w[i][j];
+        for (var t = 0; t < wij.length; t++) {
+          wij[t] = 0.0;
+        }
+      }
+    }
+
+    final coords = cube3Coords().toList();
+    for (var i = 0; i < n; i++) {
+      for (final j in nbrs[i]) {
+        final gi = couplingAt(coords[i], params);
+        final gj = couplingAt(coords[j], params);
+        final G = geoMix * (gi < gj ? gi : gj);
+
+        final wij = w[i][j];
+        for (var k = 0; k < Potts27.q; k++) {
+          for (var l = 0; l < Potts27.q; l++) {
+            wij[k * Potts27.q + l] = G * kernel(k, l);
+          }
+        }
+      }
+    }
+
+    for (var i = 0; i < n; i++) {
+      for (final j in nbrs[i]) {
+        final wij = w[i][j];
+        final wji = w[j][i];
+        for (var k = 0; k < Potts27.q; k++) {
+          for (var l = 0; l < Potts27.q; l++) {
+            wji[l * Potts27.q + k] = wij[k * Potts27.q + l];
+          }
+        }
+      }
+    }
+
+    for (var i = 0; i < n; i++) {
+      for (final j in nbrs[i]) {
+        final wij = w[i][j];
+        var norm2 = 0.0;
+        for (final v in wij) {
+          norm2 += v * v;
+        }
+        final norm = norm2 > 0 ? math.sqrt(norm2) : 0.0;
+        final s = norm > 0 ? (targetNorm / norm) : 1.0;
+        for (var t = 0; t < wij.length; t++) {
+          wij[t] *= s;
+        }
+      }
+    }
+  }
+
   /// Hebbian storage of [patterns]. Each pattern is a list of length [n]
-  /// with digits 0..26.
-  void store(List<List<int>> patterns, {double scale = 1.0}) {
+  /// with digits 0..26. After building Hebbian weights, they are symmetrized,
+  /// scaled to [targetNorm], then blended with existing weights.
+  void store(
+    List<List<int>> patterns, {
+    double scale = 0.3,
+    double targetNorm = 0.4,
+    double blend = 0.5,
+  }) {
     final invN = scale / n;
+    final wHebb = List.generate(
+      n,
+      (_) => List.generate(n, (_) => List.filled(q * q, 0.0)),
+    );
     for (final p in patterns) {
       if (p.length != n) {
         throw ArgumentError('Pattern length ${p.length} != n=$n');
@@ -58,13 +140,53 @@ class Potts27 {
         for (final j in nbrs[i]) {
           // Subtract baseline 1/q from all entries.
           final base = invN / q;
-          final wij = w[i][j];
+          final wij = wHebb[i][j];
           for (var idx = 0; idx < wij.length; idx++) {
             wij[idx] -= base;
           }
           // Add correlation for observed pair.
           final idx = p[i] * q + p[j];
           wij[idx] += invN;
+        }
+      }
+    }
+
+    // Symmetrize Hebbian weights.
+    for (var i = 0; i < n; i++) {
+      for (final j in nbrs[i]) {
+        final wij = wHebb[i][j];
+        final wji = wHebb[j][i];
+        for (var k = 0; k < q; k++) {
+          for (var l = 0; l < q; l++) {
+            wji[l * q + k] = wij[k * q + l];
+          }
+        }
+      }
+    }
+
+    // Scale each block to targetNorm.
+    for (var i = 0; i < n; i++) {
+      for (final j in nbrs[i]) {
+        final wij = wHebb[i][j];
+        var norm2 = 0.0;
+        for (final v in wij) {
+          norm2 += v * v;
+        }
+        final norm = norm2 > 0 ? math.sqrt(norm2) : 0.0;
+        final s = norm > 0 ? (targetNorm / norm) : 1.0;
+        for (var t = 0; t < wij.length; t++) {
+          wij[t] *= s;
+        }
+      }
+    }
+
+    // Blend with existing weights.
+    for (var i = 0; i < n; i++) {
+      for (final j in nbrs[i]) {
+        final wij = w[i][j];
+        final hebb = wHebb[i][j];
+        for (var t = 0; t < wij.length; t++) {
+          wij[t] = (1 - blend) * wij[t] + blend * hebb[t];
         }
       }
     }

--- a/test/potts_coupler_test.dart
+++ b/test/potts_coupler_test.dart
@@ -1,0 +1,113 @@
+import 'dart:math' as math;
+
+import 'package:test/test.dart';
+import 'package:livnium_core/livnium_core.dart';
+import 'package:livnium_core/src/potts.dart';
+
+void main() {
+  group('Potts with couplers', () {
+    test('symmetry', () {
+      final net = Potts27.cube();
+      net.buildFromCouplers(
+        params: CouplerParams(tau0: 1, alpha: 1),
+        kernel: cosKernel,
+        targetNorm: 0.5,
+      );
+      for (var i = 0; i < net.n; i++) {
+        for (final j in net.nbrs[i]) {
+          final wij = net.w[i][j];
+          final wji = net.w[j][i];
+          for (var k = 0; k < Potts27.q; k++) {
+            for (var l = 0; l < Potts27.q; l++) {
+              expect(
+                wji[l * Potts27.q + k],
+                closeTo(wij[k * Potts27.q + l], 1e-9),
+              );
+            }
+          }
+        }
+      }
+    });
+
+    test('distance monotonicity', () {
+      final net = Potts27.cube();
+      net.buildFromCouplers(
+        params: CouplerParams(tau0: 1, alpha: 1),
+        kernel: cosKernel,
+        targetNorm: 0.5,
+      );
+      final coords = cube3Coords().toList();
+      final params = CouplerParams(tau0: 1, alpha: 1);
+      final mags = <int, List<double>>{1: [], 2: [], 3: []};
+      for (var i = 0; i < coords.length; i++) {
+        final L = coords[i].x.abs() + coords[i].y.abs() + coords[i].z.abs();
+        if (L == 0) continue;
+        mags[L]!.add(couplingAt(coords[i], params));
+      }
+      double avg(List<double> xs) => xs.reduce((a, b) => a + b) / xs.length;
+      final l1 = avg(mags[1]!);
+      final l2 = avg(mags[2]!);
+      final l3 = avg(mags[3]!);
+      expect(l1 >= l2 && l2 >= l3, isTrue);
+    });
+
+    test('geometry aids recall', () {
+      final patterns = [
+        List.generate(27, (i) => i % Potts27.q),
+        List.filled(27, 3),
+        List.generate(27, (i) => (i * 2) % Potts27.q),
+      ];
+
+      Potts27 buildGeom() {
+        final net = Potts27.cube();
+        net.buildFromCouplers(
+          params: CouplerParams(tau0: 1, alpha: 1),
+          kernel: cosKernel,
+          targetNorm: 0.5,
+        );
+        net.store(patterns, blend: 0.5);
+        return net;
+      }
+
+      Potts27 buildFlat() {
+        final net = Potts27.cube();
+        net.buildFromCouplers(
+          params: CouplerParams(tau0: 1, alpha: 1),
+          kernel: cosKernel,
+          targetNorm: 0.5,
+          geoMix: 0,
+        );
+        net.store(patterns, blend: 1.0);
+        return net;
+      }
+
+      final geom = buildGeom();
+      final flat = buildFlat();
+
+      final coords = cube3Coords().toList();
+      final target = patterns[0];
+      final noisy = List<int>.from(target);
+      for (var i = 0; i < coords.length; i++) {
+        if (coords[i].z == 1) {
+          noisy[i] = (noisy[i] + 1) % Potts27.q;
+        }
+      }
+      for (var i = 0; i < geom.n; i++) {
+        geom.s[i] = noisy[i];
+        flat.s[i] = noisy[i];
+      }
+      geom.relax();
+      flat.relax();
+
+      int correct(Potts27 net) {
+        var c = 0;
+        for (var i = 0; i < net.n; i++) {
+          if (net.s[i] == target[i]) c++;
+        }
+        return c;
+      }
+
+      expect(correct(geom) >= correct(flat), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add cosine kernel and coupler-based weight builder in Potts27
- blend Hebbian storage with existing weights and demo geometric vs. flat recall
- test symmetry, coupling decay, and improved recall under block noise

## Testing
- `dart test`

------
https://chatgpt.com/codex/tasks/task_e_689d05d63a28832ea5fefdfce12afd47