### PR TITLE
Add move permutations, invariants tests, and demos

### DIFF
--- a/example/arith_carry_demo.dart
+++ b/example/arith_carry_demo.dart
@@ -1,0 +1,104 @@
+import 'dart:math';
+import 'package:livnium_core/src/arith27.dart';
+import 'package:livnium_core/livnium_core.dart';
+
+String randWord(Random rng, int len) {
+  final sb = StringBuffer();
+  for (var i = 0; i < len; i++) {
+    sb.write(valueToSymbol(rng.nextInt(kRadix))!);
+  }
+  return sb.toString();
+}
+
+({String sum, int carries, int ripple}) addPlainStats(String a, String b) {
+  int i = a.length - 1, j = b.length - 1, carry = 0;
+  int carries = 0, run = 0, maxRun = 0;
+  final out = StringBuffer();
+  while (i >= 0 || j >= 0 || carry != 0) {
+    final da = i >= 0 ? symbolToValue(a[i--])! : 0;
+    final db = j >= 0 ? symbolToValue(b[j--])! : 0;
+    var s = da + db + carry;
+    carry = s ~/ kRadix;
+    s %= kRadix;
+    out.write(valueToSymbol(s)!);
+    if (carry != 0) {
+      carries++;
+      run++;
+    } else {
+      if (run > maxRun) maxRun = run;
+      run = 0;
+    }
+  }
+  if (run > maxRun) maxRun = run;
+  final res = out.toString().split('').reversed.join();
+  return (sum: res, carries: carries, ripple: maxRun);
+}
+
+({String sum, int carries, int ripple}) addBalancedStats(String a, String b) {
+  int i = a.length - 1, j = b.length - 1, carryC = 0;
+  int carries = 0, run = 0, maxRun = 0;
+  final out = <int>[];
+  while (i >= 0 || j >= 0) {
+    final da = i >= 0 ? symbolToValue(a[i--])! : 0;
+    final db = j >= 0 ? symbolToValue(b[j--])! : 0;
+    var sc = (da - 13) + (db - 13) + carryC;
+    if (sc > 13) {
+      sc -= 27;
+      carryC = 1;
+    } else if (sc < -13) {
+      sc += 27;
+      carryC = -1;
+    } else {
+      carryC = 0;
+    }
+    out.add(sc);
+    if (carryC != 0) {
+      carries++;
+      run++;
+    } else {
+      if (run > maxRun) maxRun = run;
+      run = 0;
+    }
+  }
+  if (carryC != 0) {
+    out.add(carryC);
+    carries++;
+    run++;
+  }
+  if (run > maxRun) maxRun = run;
+  final buf = StringBuffer();
+  for (var k = out.length - 1; k >= 0; k--) {
+    buf.write(valueToSymbol(out[k] + 13)!);
+  }
+  final res = buf.toString().replaceFirst(RegExp(r'^0+'), '');
+  return (sum: res.isEmpty ? '0' : res, carries: carries, ripple: maxRun);
+}
+
+void main() {
+  final rng = Random(123);
+  print('N  carries_plain  carries_bal  ripple_plain  ripple_bal');
+  for (final N in [16, 64, 256]) {
+    int cPlain = 0, cBal = 0;
+    int rPlain = 0, rBal = 0;
+    for (var t = 0; t < 100; t++) {
+      final a = randWord(rng, N);
+      final b = randWord(rng, N);
+      final p = addPlainStats(a, b);
+      final q = addBalancedStats(a, b);
+      cPlain += p.carries;
+      cBal += q.carries;
+      rPlain += p.ripple;
+      rBal += q.ripple;
+    }
+    final avgCarriesPlain = cPlain / 100;
+    final avgCarriesBal = cBal / 100;
+    final avgRipplePlain = rPlain / 100;
+    final avgRippleBal = rBal / 100;
+    print(
+      '$N  ${avgCarriesPlain.toStringAsFixed(2)}  '
+      '${avgCarriesBal.toStringAsFixed(2)}  '
+      '${avgRipplePlain.toStringAsFixed(2)}  '
+      '${avgRippleBal.toStringAsFixed(2)}',
+    );
+  }
+}

--- a/example/interference_demo.dart
+++ b/example/interference_demo.dart
@@ -1,0 +1,11 @@
+import 'package:livnium_core/livnium_core.dart';
+
+void main() {
+  final top = rankTopCouplers(CouplerParams(tau0: 1, alpha: 1), 2);
+  final c1 = top[0].C;
+  final c2 = top[1].C;
+  for (var deg = 0; deg <= 360; deg += 15) {
+    final mag = complexSumMagnitude([(c1, 0.0), (c2, deg.toDouble())]);
+    print('$deg,$mag');
+  }
+}

--- a/example/moves_demo.dart
+++ b/example/moves_demo.dart
@@ -1,0 +1,21 @@
+import 'package:livnium_core/livnium_core.dart';
+
+void main() {
+  final symbols = List<int>.generate(27, (i) => i);
+  final orig = List<int>.from(symbols);
+
+  final seq = [FaceMove(Face.U, 1), FaceMove(Face.R, 1), FaceMove(Face.F, -1)];
+
+  print('start     : $orig');
+  applyMoves(symbols, seq);
+  print('scrambled : $symbols');
+
+  double energy(List<int> arr) =>
+      arr.map((d) => symbolEnergy9(valueToSymbol(d)!)!).reduce((a, b) => a + b);
+  print('energy orig=${energy(orig)} after=${energy(symbols)}');
+
+  final inv =
+      seq.reversed.map((m) => FaceMove(m.face, -m.quarterTurns)).toList();
+  applyMoves(symbols, inv);
+  print('restored  : $symbols');
+}

--- a/example/recall_curve.dart
+++ b/example/recall_curve.dart
@@ -1,0 +1,41 @@
+import 'dart:math';
+import 'package:livnium_core/livnium_core.dart';
+
+List<int> patternForWord(String w) {
+  final d = stringToDigits(w)!;
+  return List<int>.generate(27, (i) => d[i % d.length]);
+}
+
+void main() {
+  final words = ['love', 'grace', 'unity'];
+  final patterns = words.map(patternForWord).toList();
+
+  final net = Potts27.cube();
+  net.store(patterns, scale: 1.0, targetNorm: 0.5, blend: 1.0);
+
+  final rng = Random(42);
+  for (var p = 0.0; p <= 0.6001; p += 0.05) {
+    double acc = 0;
+    for (final pat in patterns) {
+      for (var trial = 0; trial < 5; trial++) {
+        final noisy = List<int>.from(pat);
+        final count = (p * noisy.length).round();
+        final idxs = List<int>.generate(noisy.length, (i) => i)..shuffle(rng);
+        for (var i = 0; i < count; i++) {
+          noisy[idxs[i]] = rng.nextInt(Potts27.q);
+        }
+        for (var i = 0; i < net.n; i++) {
+          net.s[i] = noisy[i];
+        }
+        net.relax(maxIters: 50);
+        var correct = 0;
+        for (var i = 0; i < pat.length; i++) {
+          if (net.s[i] == pat[i]) correct++;
+        }
+        acc += correct / pat.length;
+      }
+    }
+    final avg = acc / (patterns.length * 5);
+    print('${p.toStringAsFixed(2)},${avg.toStringAsFixed(3)}');
+  }
+}

--- a/lib/livnium_core.dart
+++ b/lib/livnium_core.dart
@@ -48,5 +48,8 @@ export 'src/grid.dart'
 export 'src/coupler.dart'
     show CouplerParams, couplingAt, rankTopCouplers, complexSumMagnitude;
 
+export 'src/moves.dart'
+    show Face, FaceMove, permutationFor, applyPerm, applyMoves;
+
 export 'src/potts.dart' show Potts27;
 export 'src/tree.dart' show CubePath, MicroCube, LivniumTree;

--- a/lib/src/moves.dart
+++ b/lib/src/moves.dart
@@ -1,0 +1,90 @@
+library;
+
+import 'grid.dart';
+import 'rotation.dart';
+import 'vec3.dart';
+
+/// Faces of the 3x3x3 cube using standard Rubik notation.
+enum Face { U, D, L, R, F, B }
+
+/// Represents a quarter-turn move on a face.
+class FaceMove {
+  final Face face;
+  final int quarterTurns; // \pm1,\pm2,\pm3
+  const FaceMove(this.face, this.quarterTurns);
+}
+
+// Pre-computed coordinate list and reverse lookup.
+final List<Vec3> _coords = cube3Coords().toList(growable: false);
+final Map<Vec3, int> _coordIndex = {
+  for (var i = 0; i < _coords.length; i++) _coords[i]: i,
+};
+
+/// Return a 27-long permutation mapping oldIndex -> newIndex for this move.
+List<int> permutationFor(FaceMove m) {
+  final perm = List<int>.generate(_coords.length, (i) => i);
+  final t = ((m.quarterTurns % 4) + 4) % 4;
+  if (t == 0) return perm;
+
+  bool Function(Vec3) select;
+  Vec3 Function(Vec3) rot;
+
+  switch (m.face) {
+    case Face.U:
+      select = (v) => v.z == 1;
+      rot = rotateZ;
+      break;
+    case Face.D:
+      select = (v) => v.z == -1;
+      rot = rotateZ;
+      break;
+    case Face.R:
+      select = (v) => v.x == 1;
+      rot = rotateX;
+      break;
+    case Face.L:
+      select = (v) => v.x == -1;
+      rot = rotateX;
+      break;
+    case Face.F:
+      select = (v) => v.y == 1;
+      rot = rotateY;
+      break;
+    case Face.B:
+      select = (v) => v.y == -1;
+      rot = rotateY;
+      break;
+  }
+
+  for (var i = 0; i < _coords.length; i++) {
+    final v = _coords[i];
+    if (select(v)) {
+      var p = v;
+      for (var k = 0; k < t; k++) {
+        p = rot(p);
+      }
+      final j = _coordIndex[p]!;
+      perm[i] = j;
+    }
+  }
+  return perm;
+}
+
+/// Apply a permutation to a symbol array (in-place).
+void applyPerm<T>(List<T> symbols, List<int> perm) {
+  if (symbols.length != perm.length) {
+    throw ArgumentError('symbols and perm must have same length');
+  }
+  final tmp = List<T>.from(symbols);
+  for (var i = 0; i < perm.length; i++) {
+    symbols[perm[i]] = tmp[i];
+  }
+}
+
+/// Convenience: apply a sequence of face moves.
+void applyMoves(List<int> symbols, List<FaceMove> seq) {
+  for (final m in seq) {
+    final perm = permutationFor(m);
+    applyPerm<int>(symbols, perm);
+  }
+}

--- a/test/arith_balanced_test.dart
+++ b/test/arith_balanced_test.dart
@@ -1,0 +1,17 @@
+import 'package:test/test.dart';
+import 'package:livnium_core/src/arith27.dart';
+
+void main() {
+  test('balanced addition equals BigInt addition', () {
+    final cases = [
+      ['a', 'z'],
+      ['love', 'love'],
+      ['zzzz', 'a1a1'.replaceAll('1', 'a')],
+    ];
+    for (final c in cases) {
+      final got = add27Balanced(c[0], c[1])!;
+      final want = fromDecimal(toDecimal(c[0])! + toDecimal(c[1])!)!;
+      expect(got, equals(want));
+    }
+  });
+}

--- a/test/moves_invariants_test.dart
+++ b/test/moves_invariants_test.dart
@@ -1,0 +1,61 @@
+import 'dart:math';
+import 'package:test/test.dart';
+import 'package:livnium_core/livnium_core.dart';
+
+void main() {
+  test('permutation invertibility & energy invariants', () {
+    final coords = cube3Coords().toList();
+    final symbols = List<int>.generate(coords.length, (i) => i);
+    final origSymbols = List<int>.from(symbols);
+    final origCoords = List<Vec3>.from(coords);
+
+    final rng = Random(1234);
+    final faces = Face.values;
+    final seq = List.generate(100, (_) {
+      final f = faces[rng.nextInt(faces.length)];
+      final q = rng.nextInt(3) + 1; // 1..3
+      final sign = rng.nextBool() ? 1 : -1;
+      return FaceMove(f, q * sign);
+    });
+
+    for (final m in seq) {
+      final perm = permutationFor(m);
+      applyPerm<int>(symbols, perm);
+      // also permute coordinates to track geometry
+      final tmp = List<Vec3>.from(coords);
+      for (var i = 0; i < perm.length; i++) {
+        coords[perm[i]] = tmp[i];
+      }
+    }
+
+    double energy(List<int> arr) => arr
+        .map((d) => symbolEnergy9(valueToSymbol(d)!)!)
+        .reduce((a, b) => a + b);
+    expect(energy(symbols), equals(energy(origSymbols)));
+
+    final coreCount = coords.where(isCore).length;
+    final centerCount = coords.where(isCenter).length;
+    final edgeCount = coords.where(isEdge).length;
+    final cornerCount = coords.where(isCorner).length;
+    expect([
+      coreCount,
+      centerCount,
+      edgeCount,
+      cornerCount,
+    ], equals([1, 6, 12, 8]));
+
+    final inv = seq.reversed
+        .map((m) => FaceMove(m.face, -m.quarterTurns))
+        .toList(growable: false);
+    applyMoves(symbols, inv);
+    for (final m in inv) {
+      final perm = permutationFor(m);
+      final tmp = List<Vec3>.from(coords);
+      for (var i = 0; i < perm.length; i++) {
+        coords[perm[i]] = tmp[i];
+      }
+    }
+    expect(symbols, equals(origSymbols));
+    expect(coords, equals(origCoords));
+  });
+}


### PR DESCRIPTION
## Summary
- implement 3×3×3 face move permutations and helpers
- add tests for move invariants and balanced addition
- provide demos for moves, recall curve, interference, and arithmetic carry

## Testing
- `dart test`
- `dart run example/moves_demo.dart`
- `dart run example/recall_curve.dart > recall.csv`
- `dart run example/interference_demo.dart > interference.csv`
- `dart run example/arith_carry_demo.dart`


------
https://chatgpt.com/codex/tasks/task_e_689d0bcd26e8832e9ecc61e0db60c2c0