### PR TITLE
Add tool to dump source files into single file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/
 # VS Code / IntelliJ caches
 .idea/
 .vscode/
+dump.txt

--- a/tool/dump.dart
+++ b/tool/dump.dart
@@ -1,0 +1,30 @@
+import 'dart:io';
+
+/// Generates a combined dump of all Dart source files found in the `lib`,
+/// `test`, and `example` directories. The content is written to `dump.txt`
+/// in the project root. Existing files are overwritten.
+void main() {
+  final directories = ['lib', 'test', 'example'];
+  final buffer = StringBuffer();
+
+  for (final dirPath in directories) {
+    final dir = Directory(dirPath);
+    if (!dir.existsSync()) {
+      // Skip missing directories.
+      continue;
+    }
+
+    for (final entity in dir.listSync(recursive: true)) {
+      if (entity is! File) continue;
+      if (!entity.path.endsWith('.dart')) continue;
+
+      buffer
+        ..writeln('//// BEGIN FILE: ${entity.path}')
+        ..writeln(entity.readAsStringSync())
+        ..writeln('//// END FILE: ${entity.path}')
+        ..writeln();
+    }
+  }
+
+  File('dump.txt').writeAsStringSync(buffer.toString());
+}


### PR DESCRIPTION
## Summary
- add `tool/dump.dart` to concatenate Dart sources from lib, test, and example into `dump.txt`
- ignore generated `dump.txt`

## Testing
- `dart test`
- `dart analyze`
- `dart run tool/dump.dart`


------
https://chatgpt.com/codex/tasks/task_e_689d0e4e93c4832ebd4260c9f1456682