### PR TITLE
Add tools to dump source and example outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ build/
 # VS Code / IntelliJ caches
 .idea/
 .vscode/
+dump.txt
+dump-example-log.dart

--- a/tool/dump.dart
+++ b/tool/dump.dart
@@ -1,0 +1,30 @@
+import 'dart:io';
+
+/// Generates a combined dump of all Dart source files found in the `lib`,
+/// `test`, and `example` directories. The content is written to `dump.txt`
+/// in the project root. Existing files are overwritten.
+void main() {
+  final directories = ['lib', 'test', 'example'];
+  final buffer = StringBuffer();
+
+  for (final dirPath in directories) {
+    final dir = Directory(dirPath);
+    if (!dir.existsSync()) {
+      // Skip missing directories.
+      continue;
+    }
+
+    for (final entity in dir.listSync(recursive: true)) {
+      if (entity is! File) continue;
+      if (!entity.path.endsWith('.dart')) continue;
+
+      buffer
+        ..writeln('//// BEGIN FILE: ${entity.path}')
+        ..writeln(entity.readAsStringSync())
+        ..writeln('//// END FILE: ${entity.path}')
+        ..writeln();
+    }
+  }
+
+  File('dump.txt').writeAsStringSync(buffer.toString());
+}

--- a/tool/dump_example_log.dart
+++ b/tool/dump_example_log.dart
@@ -1,0 +1,32 @@
+import 'dart:io';
+
+/// Runs all Dart example scripts in the `example` directory and writes their
+/// combined stdout/stderr to `dump-example-log.dart` in the project root.
+/// Existing files are overwritten.
+void main() {
+  final exampleDir = Directory('example');
+  if (!exampleDir.existsSync()) {
+    stderr.writeln('example directory not found');
+    exit(1);
+  }
+
+  final buffer = StringBuffer();
+
+  for (final entity in exampleDir.listSync(recursive: true)) {
+    if (entity is! File) continue;
+    if (!entity.path.endsWith('.dart')) continue;
+
+    buffer.writeln('//// BEGIN EXAMPLE: ${entity.path}');
+
+    final result = Process.runSync('dart', ['run', entity.path]);
+    final out = result.stdout.toString();
+    final err = result.stderr.toString();
+    if (out.isNotEmpty) buffer.writeln(out.trimRight());
+    if (err.isNotEmpty) buffer.writeln(err.trimRight());
+
+    buffer.writeln('//// END EXAMPLE: ${entity.path}');
+    buffer.writeln();
+  }
+
+  File('dump-example-log.dart').writeAsStringSync(buffer.toString());
+}


### PR DESCRIPTION
## Summary
- add `tool/dump.dart` to concatenate Dart sources from lib, test, and example into `dump.txt`
- add `tool/dump_example_log.dart` to run examples and write their stdout/stderr to `dump-example-log.dart`
- ignore generated `dump.txt` and `dump-example-log.dart`

## Testing
- `dart test`
- `dart analyze`
- `dart run tool/dump_example_log.dart`


------
https://chatgpt.com/codex/tasks/task_e_689d0e4e93c4832ebd4260c9f1456682