### PR TITLE
Implement balanced base-27 arithmetic

### DIFF
--- a/lib/src/arith27.dart
+++ b/lib/src/arith27.dart
@@ -7,6 +7,9 @@ const int _R = 27;
 int? _d(String ch) => symbolToValue(ch);
 String? _g(int v) => valueToSymbol(v);
 
+/// Whether [s] consists solely of valid base-27 symbols.
+///
+/// The empty string is permitted and treated as representing zero.
 bool _valid(String s) => s.split('').every((c) => _d(c) != null);
 
 String _stripLeadingZeros(String s) {
@@ -15,9 +18,12 @@ String _stripLeadingZeros(String s) {
   return s.substring(i);
 }
 
-/// Convert a Livnium base-27 word to BigInt.
+/// Convert a Livnium base-27 word to [BigInt].
+///
+/// An empty string is interpreted as zero.
 BigInt? toDecimal(String s) {
   if (!_valid(s)) return null;
+  if (s.isEmpty) return BigInt.zero;
   var acc = BigInt.zero;
   for (final ch in s.split('')) {
     final dv = _d(ch)!;
@@ -26,7 +32,7 @@ BigInt? toDecimal(String s) {
   return acc;
 }
 
-/// Convert non-negative BigInt to Livnium base-27 word.
+/// Convert a non-negative [BigInt] to a Livnium base-27 word.
 String? fromDecimal(BigInt n) {
   if (n.isNegative) return null;
   if (n == BigInt.zero) return '0';
@@ -47,7 +53,10 @@ String? fromDecimal(BigInt n) {
   return _stripLeadingZeros(buf.toString());
 }
 
-/// Standard base-27 addition with carries. Returns `null` on invalid input.
+/// Standard base-27 addition with carries.
+///
+/// Empty strings are treated as zero. Returns `null` if either input contains
+/// an invalid symbol.
 String? add27(String a, String b) {
   if (!_valid(a) || !_valid(b)) return null;
   if (a.isEmpty && b.isEmpty) return '0';
@@ -74,14 +83,48 @@ String? add27(String a, String b) {
   return stripped.isEmpty ? '0' : stripped;
 }
 
-/// Balanced-carry addition (centered digits −13..+13). Same result as [add27].
+/// Balanced-carry addition using centered digits −13‥+13.
+///
+/// The result matches [add27] but carries are propagated symmetrically so that
+/// each intermediate digit stays near the center value 13. Empty strings are
+/// treated as zero.
 String? add27Balanced(String a, String b) {
-  // Balanced addition currently delegates to [add27] but retains the
-  // signature for experimentation with alternative carry schemes.
-  return add27(a, b);
+  if (!_valid(a) || !_valid(b)) return null;
+  if (a.isEmpty && b.isEmpty) return '0';
+  if (a.isEmpty)
+    return _stripLeadingZeros(b).isEmpty ? '0' : _stripLeadingZeros(b);
+  if (b.isEmpty)
+    return _stripLeadingZeros(a).isEmpty ? '0' : _stripLeadingZeros(a);
+
+  int i = a.length - 1, j = b.length - 1, carry = 0;
+  final out = StringBuffer();
+  while (i >= 0 || j >= 0 || carry != 0) {
+    final da = (i >= 0) ? _d(a[i--])! : 0;
+    final db = (j >= 0) ? _d(b[j--])! : 0;
+    var s = da + db + carry - 13; // center around zero
+    if (s > 13) {
+      s -= 27;
+      carry = 1;
+    } else if (s < -13) {
+      s += 27;
+      carry = -1;
+    } else {
+      carry = 0;
+    }
+    final digit = s + 13;
+    final ch = _g(digit);
+    if (ch == null) return null;
+    out.write(ch);
+  }
+  final res = out.toString().split('').reversed.join();
+  final stripped = _stripLeadingZeros(res);
+  return stripped.isEmpty ? '0' : stripped;
 }
 
 /// Per-digit modulo-27 addition without carry propagation.
+///
+/// The shorter operand is treated as being left-padded with zeros. Empty
+/// strings are interpreted as zero.
 String? add27Cyclic(String a, String b) {
   if (!_valid(a) || !_valid(b)) return null;
   if (a.isEmpty && b.isEmpty) return '0';
@@ -105,6 +148,9 @@ String? add27Cyclic(String a, String b) {
 }
 
 /// Carry-save addition of three operands. Returns partial sum and carry.
+///
+/// Empty operands are treated as zero. The returned tuple's fields are both
+/// normalized base-27 words.
 ({String sum, String carry})? add27CarrySave3(String a, String b, String c) {
   if (!_valid(a) || !_valid(b) || !_valid(c)) return null;
   if (a.isEmpty && b.isEmpty && c.isEmpty) {
@@ -134,7 +180,11 @@ String? add27Cyclic(String a, String b) {
 }
 
 /// Finalize a carry-save addition produced by [add27CarrySave3].
+///
+/// Computes `sum + (carry << 1 digit)` in base‑27. Empty inputs are treated
+/// as zero.
 String? csFinish(String sum, String carry) {
   if (!_valid(sum) || !_valid(carry)) return null;
+  if (sum.isEmpty && carry.isEmpty) return '0';
   return add27(sum, '${carry}0');
 }

--- a/test/arith27_test.dart
+++ b/test/arith27_test.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 import 'package:test/test.dart';
 import 'package:livnium_core/src/arith27.dart';
+import 'package:livnium_core/src/alphabet.dart';
 
 String randWord(Random rng, int len) {
   // digits 0..26 → symbols
@@ -86,6 +87,10 @@ void main() {
       expect(add27('', ''), '0');
       expect(add27Balanced('', 'a'), 'a');
       expect(add27Cyclic('z', 'a'), '0');
+      final cs = add27CarrySave3('', '', '')!;
+      expect(cs.sum, '0');
+      expect(cs.carry, '0');
+      expect(csFinish('', ''), '0');
     });
 
     test('modular addition without carry', () {
@@ -128,6 +133,24 @@ void main() {
         expect(s1, equals(sumWord));
         expect(s2, equals(sumWord));
         expect(s3, equals(sumWord));
+      }
+    });
+
+    test('cyclic addition matches digitwise modular sum', () {
+      final rng = Random(2024);
+      for (var t = 0; t < 1000; t++) {
+        final a = randWord(rng, rng.nextInt(40) + 1);
+        final b = randWord(rng, rng.nextInt(40) + 1);
+        final cyc = add27Cyclic(a, b)!;
+        final n = max(a.length, b.length);
+        for (var i = 0; i < n; i++) {
+          final da = i < a.length ? symbolToValue(a[a.length - 1 - i])! : 0;
+          final db = i < b.length ? symbolToValue(b[b.length - 1 - i])! : 0;
+          final expected = (da + db) % 27;
+          final rc =
+              i < cyc.length ? symbolToValue(cyc[cyc.length - 1 - i])! : 0;
+          expect(rc, expected);
+        }
       }
     });
 


### PR DESCRIPTION
## Summary
- Document empty-string arithmetic semantics and implement balanced-carry addition using centred digits
- Provide cyclic and carry-save addition helpers with comprehensive property tests
- Cover carry-save and cyclic helpers in empty-string tests

## Testing
- `dart analyze`
- `dart test`
- `dart example/core_bit_demo.dart`

------
https://chatgpt.com/codex/tasks/task_e_689d3134cc54832eafe82d65a6b03eb1