### PR TITLE
docs: move arithmetic API to second in docs sidebar

### DIFF
--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -19,6 +19,7 @@ const sidebars: SidebarsConfig = {
       label: 'API Reference',
       items: [
         'api/alphabet',
+        'api/arith27',
         'api/energy',
         'api/grid',
         'api/rotation-moves',
@@ -26,7 +27,6 @@ const sidebars: SidebarsConfig = {
         'api/potts',
         'api/tree-corebit',
         'api/projection',
-        'api/arith27',
       ],
     },
     {


### PR DESCRIPTION
## Summary
- move Arithmetic API second in API Reference sidebar

## Testing
- `dart test`
- `npm run --prefix docs-site typecheck` *(fails: Cannot find module '@theme/Heading')*

------
https://chatgpt.com/codex/tasks/task_e_689e6b629378832eafe9126430a4fef5