### PR TITLE
fix: align visualizer types with core API

### DIFF
--- a/livnium-visualizer/types/livnium.d.ts
+++ b/livnium-visualizer/types/livnium.d.ts
@@ -1,4 +1,6 @@
 export type CouplerParams = { tau0: number; alpha: number };
+export type Face = 'U' | 'D' | 'L' | 'R' | 'F' | 'B';
+export type FaceMove = { face: Face; quarterTurns: number };
 
 export interface LivniumAPI {
   add27(a: string, b: string): string | null;
@@ -17,8 +19,8 @@ export interface LivniumAPI {
   perFaceUnitEnergy(faces: number): number;
   equilibriumConstant(): number;
 
-  permutationFor(m: { face: string; quarterTurns: number }): number[];
-  applyPerm<T>(arr: T[], perm: number[]): void;
+  permutationFor(m: FaceMove): number[];
+  applyPerm(symbols: number[], perm: number[]): void;
 
   makeCouplerParams(tau0: number, alpha: number): CouplerParams;
   couplingAt(x: number, y: number, z: number, p: CouplerParams): number;


### PR DESCRIPTION
## Summary
- refine Livnium visualizer TypeScript types to mirror core API
- restrict face moves to explicit face literals and tighten applyPerm typing

## Testing
- `dart test`
- `npm test` (fails: Error: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_689eed42a6e8832e84ef63927da26bab