### PR TITLE
feat: add visualizer source dump tool

### DIFF
--- a/tool/dump-visualizer-src.dart
+++ b/tool/dump-visualizer-src.dart
@@ -1,0 +1,34 @@
+import 'dart:io';
+
+/// Generates a combined dump of all Visualizer source files found in the
+/// `visualizer/src` directory. The content is written to
+/// `dump-visualizer-src.txt` in the project root. Existing files are
+/// overwritten.
+void main() {
+  final dir = Directory('visualizer/src');
+  if (!dir.existsSync()) {
+    stderr.writeln('visualizer/src directory not found');
+    exit(1);
+  }
+
+  final buffer = StringBuffer();
+
+  for (final entity in dir.listSync(recursive: true)) {
+    if (entity is! File) continue;
+    final path = entity.path;
+    if (!path.endsWith('.js') &&
+        !path.endsWith('.jsx') &&
+        !path.endsWith('.ts') &&
+        !path.endsWith('.tsx')) {
+      continue;
+    }
+
+    buffer
+      ..writeln('//// BEGIN FILE: $path')
+      ..writeln(entity.readAsStringSync())
+      ..writeln('//// END FILE: $path')
+      ..writeln();
+  }
+
+  File('dump-visualizer-src.txt').writeAsStringSync(buffer.toString());
+}


### PR DESCRIPTION
## Summary
- add dump-visualizer-src.dart for concatenating visualizer/src files

## Testing
- `dart format tool/dump-visualizer-src.dart`
- `dart analyze` *(fails: cannot resolve packages, 513 issues)*
- `dart test`


------
https://chatgpt.com/codex/tasks/task_e_689f0a121af8832eb040ef0b5611472c