### PR TITLE
Scaffold multi-panel layout with centralized store

### DIFF
--- a/visualizer/src/app/App.jsx
+++ b/visualizer/src/app/App.jsx
@@ -1,6 +1,11 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { Canvas } from '@react-three/fiber';
 import { Scene } from '../components/Scene.jsx';
+import { StoreProvider } from './store.js';
+import { TopBar } from '../components/TopBar.jsx';
+import { LeftControls } from '../components/LeftControls.jsx';
+import { Insights } from '../components/Insights.jsx';
+import { BottomStrip } from '../components/BottomStrip.jsx';
 
 export function App() {
   const cubes = useMemo(() => {
@@ -12,145 +17,27 @@ export function App() {
     return list;
   }, []);
 
-  const [mode, setMode] = useState('exposure');
-  const [alpha, setAlpha] = useState(1);
-  const [tau0, setTau0] = useState(1);
-  const [drop, setDrop] = useState('none');
-  const [slice, setSlice] = useState(0);
-  const [showNames, setShowNames] = useState(false);
-  const [labelMode, setLabelMode] = useState('xyz');
-
-  const reset = () => {
-    setMode('exposure');
-    setAlpha(1);
-    setTau0(1);
-    setDrop('none');
-    setSlice(0);
-    setShowNames(false);
-    setLabelMode('xyz');
-  };
-
-  const btn =
-    'px-3 py-1 rounded-xl border border-white/20 bg-white/5 hover:bg-white/10 transition text-sm';
-  const label = 'text-xs uppercase tracking-wide text-white/70';
-
   return (
-    <div className="w-full h-full grid grid-rows-[auto_1fr] bg-neutral-950 text-white">
-      <div className="flex flex-wrap items-center gap-3 p-3 border-b border-white/10">
-        <div className="flex items-center gap-2">
-          <span className={label}>Color</span>
-          <button
-            className={`${btn} ${mode === 'exposure' ? 'ring-2 ring-orange-400' : ''}`}
-            onClick={() => setMode('exposure')}
-          >
-            Exposure
-          </button>
-          <button
-            className={`${btn} ${mode === 'coupler' ? 'ring-2 ring-orange-400' : ''}`}
-            onClick={() => setMode('coupler')}
-          >
-            Coupler Heat
-          </button>
+    <StoreProvider>
+      <div className="w-full h-full grid grid-rows-[auto_1fr_auto] grid-cols-[auto_1fr_auto] bg-neutral-950 text-white">
+        <div className="row-start-1 col-span-3">
+          <TopBar />
         </div>
-
-        {mode === 'coupler' && (
-          <div className="flex items-center gap-2 ml-4">
-            <span className={label}>alpha</span>
-            <input
-              type="range"
-              min={0}
-              max={3}
-              step={0.1}
-              value={alpha}
-              onChange={(e) => setAlpha(parseFloat(e.target.value))}
-            />
-            <span className="tabular-nums">{alpha.toFixed(1)}</span>
-            <span className={label}>tau0</span>
-            <input
-              type="range"
-              min={0.1}
-              max={2}
-              step={0.1}
-              value={tau0}
-              onChange={(e) => setTau0(parseFloat(e.target.value))}
-            />
-            <span className="tabular-nums">{tau0.toFixed(1)}</span>
-          </div>
-        )}
-
-        <div className="flex items-center gap-2 ml-4">
-          <span className={label}>Drop Axis</span>
-          {['none', 'x', 'y', 'z'].map((k) => (
-            <button
-              key={k}
-              className={`${btn} ${drop === k ? 'ring-2 ring-sky-400' : ''}`}
-              onClick={() => setDrop(k)}
-            >
-              {k === 'none' ? 'None' : k.toUpperCase()}
-            </button>
-          ))}
-          {drop !== 'none' && (
-            <div className="flex items-center gap-2 ml-2">
-              <span className={label}>Slice</span>
-              {[-1, 0, 1].map((s) => (
-                <button
-                  key={s}
-                  className={`${btn} ${slice === s ? 'ring-2 ring-sky-400' : ''}`}
-                  onClick={() => setSlice(s)}
-                >
-                  {s}
-                </button>
-              ))}
-            </div>
-          )}
+        <div className="row-start-2 col-start-1">
+          <LeftControls />
         </div>
-
-        <div className="flex items-center gap-3 ml-4">
-          <label className="flex items-center gap-2 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={showNames}
-              onChange={(e) => setShowNames(e.target.checked)}
-            />
-            <span className={label}>Show Labels</span>
-          </label>
+        <div className="row-start-2 col-start-2 relative">
+          <Canvas camera={{ position: [5, 5, 6], fov: 45 }}>
+            <Scene cubes={cubes} />
+          </Canvas>
         </div>
-
-        <div className="flex items-center gap-2 ml-4">
-          <span className={label}>Label Mode</span>
-          <button
-            className={`${btn} ${labelMode === 'xyz' ? 'ring-2 ring-violet-400' : ''}`}
-            onClick={() => setLabelMode('xyz')}
-          >
-            XYZ
-          </button>
-          <button
-            className={`${btn} ${labelMode === 'face' ? 'ring-2 ring-violet-400' : ''}`}
-            onClick={() => setLabelMode('face')}
-          >
-            Face letters
-          </button>
+        <div className="row-start-2 col-start-3">
+          <Insights />
         </div>
-
-        <button className={`${btn} ml-2`} onClick={reset}>
-          Reset
-        </button>
+        <div className="row-start-3 col-span-3">
+          <BottomStrip />
+        </div>
       </div>
-
-      <div className="relative h-[calc(100vh-56px)]">
-        <Canvas camera={{ position: [5, 5, 6], fov: 45 }}>
-          <Scene
-            cubes={cubes}
-            mode={mode}
-            alpha={alpha}
-            tau0={tau0}
-            drop={drop}
-            slice={slice}
-            showNames={showNames}
-            labelMode={labelMode}
-          />
-        </Canvas>
-      </div>
-    </div>
+    </StoreProvider>
   );
 }

--- a/visualizer/src/app/store.js
+++ b/visualizer/src/app/store.js
@@ -1,0 +1,55 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const StoreContext = createContext();
+
+export function StoreProvider({ children }) {
+  const [mode, setMode] = useState('exposure');
+  const [alpha, setAlpha] = useState(1);
+  const [tau0, setTau0] = useState(1);
+  const [drop, setDrop] = useState('none');
+  const [slice, setSlice] = useState(0);
+  const [showLabels, setShowLabels] = useState(false);
+  const [labelMode, setLabelMode] = useState('xyz');
+  const [selection, setSelection] = useState(null);
+  const [showAxes, setShowAxes] = useState(true);
+
+  const reset = () => {
+    setMode('exposure');
+    setAlpha(1);
+    setTau0(1);
+    setDrop('none');
+    setSlice(0);
+    setShowLabels(false);
+    setLabelMode('xyz');
+    setSelection(null);
+    setShowAxes(true);
+  };
+
+  const value = {
+    mode,
+    setMode,
+    alpha,
+    setAlpha,
+    tau0,
+    setTau0,
+    drop,
+    setDrop,
+    slice,
+    setSlice,
+    showLabels,
+    setShowLabels,
+    labelMode,
+    setLabelMode,
+    selection,
+    setSelection,
+    showAxes,
+    setShowAxes,
+    reset,
+  };
+
+  return <StoreContext.Provider value={value}>{children}</StoreContext.Provider>;
+}
+
+export function useStore() {
+  return useContext(StoreContext);
+}

--- a/visualizer/src/components/BottomStrip.jsx
+++ b/visualizer/src/components/BottomStrip.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { useStore } from '../app/store.js';
+
+export function BottomStrip() {
+  const { mode, alpha, tau0, drop, slice } = useStore();
+  const status =
+    mode === 'coupler'
+      ? `Coupler α=${alpha.toFixed(1)} τ₀=${tau0.toFixed(1)}`
+      : 'Exposure';
+  return (
+    <div className="h-8 flex items-center justify-between px-3 border-t border-white/10 text-xs bg-neutral-900">
+      <div className="flex items-center gap-2">
+        <span>Legend</span>
+      </div>
+      <div className="flex items-center gap-4">
+        <span>{status}</span>
+        {drop !== 'none' && <span>Drop {drop.toUpperCase()} Slice {slice}</span>}
+      </div>
+    </div>
+  );
+}

--- a/visualizer/src/components/Insights.jsx
+++ b/visualizer/src/components/Insights.jsx
@@ -1,0 +1,25 @@
+import React, { useState } from 'react';
+
+const tabs = ['Projections', 'Couplers', 'Energy', 'Mapping', 'L1'];
+
+export function Insights() {
+  const [tab, setTab] = useState('Projections');
+  return (
+    <div className="w-64 h-full border-l border-white/10 flex flex-col text-xs">
+      <div className="flex">
+        {tabs.map((t) => (
+          <button
+            key={t}
+            className={`flex-1 px-2 py-1 border-b border-white/10 ${tab === t ? 'bg-white/10' : ''}`}
+            onClick={() => setTab(t)}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+      <div className="p-2 flex-1 overflow-auto">
+        <div className="opacity-70">{tab} panel coming soon</div>
+      </div>
+    </div>
+  );
+}

--- a/visualizer/src/components/LeftControls.jsx
+++ b/visualizer/src/components/LeftControls.jsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { useStore } from '../app/store.js';
+
+export function LeftControls() {
+  const {
+    mode,
+    setMode,
+    alpha,
+    setAlpha,
+    tau0,
+    setTau0,
+    drop,
+    setDrop,
+    slice,
+    setSlice,
+    showLabels,
+    setShowLabels,
+    labelMode,
+    setLabelMode,
+    reset,
+    showAxes,
+    setShowAxes,
+  } = useStore();
+
+  const btn =
+    'px-2 py-1 rounded border border-white/20 bg-white/5 hover:bg-white/10 text-xs';
+  const label = 'text-[10px] uppercase tracking-wide text-white/60';
+
+  return (
+    <div className="w-32 h-full border-r border-white/10 p-2 flex flex-col gap-4 text-white/80">
+      <div>
+        <div className={label}>Mode</div>
+        <div className="flex flex-col gap-1 mt-1">
+          <button
+            className={`${btn} ${mode === 'exposure' ? 'ring-1 ring-orange-400' : ''}`}
+            onClick={() => setMode('exposure')}
+          >
+            Exposure
+          </button>
+          <button
+            className={`${btn} ${mode === 'coupler' ? 'ring-1 ring-orange-400' : ''}`}
+            onClick={() => setMode('coupler')}
+          >
+            Coupler
+          </button>
+        </div>
+        {mode === 'coupler' && (
+          <div className="flex flex-col items-center gap-1 mt-2">
+            <label className={label}>α {alpha.toFixed(1)}</label>
+            <input
+              type="range"
+              min={0}
+              max={3}
+              step={0.1}
+              value={alpha}
+              onChange={(e) => setAlpha(parseFloat(e.target.value))}
+              orient="vertical"
+              className="w-full h-16"
+            />
+            <label className={label}>τ₀ {tau0.toFixed(1)}</label>
+            <input
+              type="range"
+              min={0.1}
+              max={2}
+              step={0.1}
+              value={tau0}
+              onChange={(e) => setTau0(parseFloat(e.target.value))}
+              orient="vertical"
+              className="w-full h-16"
+            />
+          </div>
+        )}
+      </div>
+
+      <div>
+        <div className={label}>Drop</div>
+        <div className="flex flex-col gap-1 mt-1">
+          {['none', 'x', 'y', 'z'].map((k) => (
+            <button
+              key={k}
+              className={`${btn} ${drop === k ? 'ring-1 ring-sky-400' : ''}`}
+              onClick={() => setDrop(k)}
+            >
+              {k === 'none' ? 'None' : k.toUpperCase()}
+            </button>
+          ))}
+        </div>
+        {drop !== 'none' && (
+          <div className="flex flex-col gap-1 mt-2">
+            <div className={label}>Slice</div>
+            {[-1, 0, 1].map((s) => (
+              <button
+                key={s}
+                className={`${btn} ${slice === s ? 'ring-1 ring-sky-400' : ''}`}
+                onClick={() => setSlice(s)}
+              >
+                {s}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div>
+        <label className="flex items-center gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={showLabels}
+            onChange={(e) => setShowLabels(e.target.checked)}
+          />
+          <span className={label}>Labels</span>
+        </label>
+        {showLabels && (
+          <div className="flex flex-col gap-1 mt-1">
+            <button
+              className={`${btn} ${labelMode === 'xyz' ? 'ring-1 ring-violet-400' : ''}`}
+              onClick={() => setLabelMode('xyz')}
+            >
+              XYZ
+            </button>
+            <button
+              className={`${btn} ${labelMode === 'face' ? 'ring-1 ring-violet-400' : ''}`}
+              onClick={() => setLabelMode('face')}
+            >
+              Face
+            </button>
+          </div>
+        )}
+      </div>
+
+      <div>
+        <div className={label}>View</div>
+        <div className="flex flex-col gap-1 mt-1">
+          <button className={btn} onClick={reset}>
+            Reset UI
+          </button>
+          <button
+            className={`${btn} ${showAxes ? 'ring-1 ring-green-400' : ''}`}
+            onClick={() => setShowAxes(!showAxes)}
+          >
+            Axes
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/visualizer/src/components/Scene.jsx
+++ b/visualizer/src/components/Scene.jsx
@@ -4,17 +4,20 @@ import { isHiddenByDrop } from '../lib/slicing.js';
 import { Axes } from './Axes.jsx';
 import { Controls } from './Controls.jsx';
 import { Cubelet } from './Cubelet.jsx';
+import { useStore } from '../app/store.js';
 
-export function Scene({
-  cubes,
-  mode,
-  alpha,
-  tau0,
-  drop,
-  slice,
-  showNames,
-  labelMode,
-}) {
+export function Scene({ cubes }) {
+  const {
+    mode,
+    alpha,
+    tau0,
+    drop,
+    slice,
+    showLabels,
+    labelMode,
+    showAxes,
+  } = useStore();
+
   const shared = useSharedGeometries();
 
   const renderCubelet = (c) => {
@@ -24,7 +27,7 @@ export function Scene({
         key={c.id}
         pos={c.pos}
         labelMode={labelMode}
-        showNames={showNames}
+        showNames={showLabels}
         mode={mode}
         alpha={alpha}
         tau0={tau0}
@@ -38,7 +41,7 @@ export function Scene({
     <>
       <ambientLight intensity={0.7} />
       <directionalLight position={[5, 8, 10]} intensity={0.9} />
-      <Axes size={4} />
+      {showAxes && <Axes size={4} />}
       {cubes.map(renderCubelet)}
       <Controls enablePan enableZoom enableRotate />
     </>

--- a/visualizer/src/components/TopBar.jsx
+++ b/visualizer/src/components/TopBar.jsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { useStore } from '../app/store.js';
+
+export function TopBar() {
+  const {
+    mode,
+    setMode,
+    alpha,
+    setAlpha,
+    tau0,
+    setTau0,
+    drop,
+    setDrop,
+    slice,
+    setSlice,
+    showLabels,
+    setShowLabels,
+    labelMode,
+    setLabelMode,
+    reset,
+  } = useStore();
+
+  const btn =
+    'px-3 py-1 rounded-xl border border-white/20 bg-white/5 hover:bg-white/10 transition text-sm';
+  const label = 'text-xs uppercase tracking-wide text-white/70';
+
+  return (
+    <div className="flex flex-wrap items-center gap-3 p-3 border-b border-white/10">
+      <div className="flex items-center gap-2">
+        <span className={label}>Color</span>
+        <button
+          className={`${btn} ${mode === 'exposure' ? 'ring-2 ring-orange-400' : ''}`}
+          onClick={() => setMode('exposure')}
+        >
+          Exposure
+        </button>
+        <button
+          className={`${btn} ${mode === 'coupler' ? 'ring-2 ring-orange-400' : ''}`}
+          onClick={() => setMode('coupler')}
+        >
+          Coupler
+        </button>
+      </div>
+
+      {mode === 'coupler' && (
+        <div className="flex items-center gap-2 ml-4">
+          <span className={label}>alpha</span>
+          <input
+            type="range"
+            min={0}
+            max={3}
+            step={0.1}
+            value={alpha}
+            onChange={(e) => setAlpha(parseFloat(e.target.value))}
+          />
+          <span className="tabular-nums">{alpha.toFixed(1)}</span>
+          <span className={label}>tau0</span>
+          <input
+            type="range"
+            min={0.1}
+            max={2}
+            step={0.1}
+            value={tau0}
+            onChange={(e) => setTau0(parseFloat(e.target.value))}
+          />
+          <span className="tabular-nums">{tau0.toFixed(1)}</span>
+        </div>
+      )}
+
+      <div className="flex items-center gap-2 ml-4">
+        <span className={label}>Drop Axis</span>
+        {['none', 'x', 'y', 'z'].map((k) => (
+          <button
+            key={k}
+            className={`${btn} ${drop === k ? 'ring-2 ring-sky-400' : ''}`}
+            onClick={() => setDrop(k)}
+          >
+            {k === 'none' ? 'None' : k.toUpperCase()}
+          </button>
+        ))}
+        {drop !== 'none' && (
+          <div className="flex items-center gap-2 ml-2">
+            <span className={label}>Slice</span>
+            {[-1, 0, 1].map((s) => (
+              <button
+                key={s}
+                className={`${btn} ${slice === s ? 'ring-2 ring-sky-400' : ''}`}
+                onClick={() => setSlice(s)}
+              >
+                {s}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center gap-3 ml-4">
+        <label className="flex items-center gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={showLabels}
+            onChange={(e) => setShowLabels(e.target.checked)}
+          />
+          <span className={label}>Show Labels</span>
+        </label>
+      </div>
+
+      <div className="flex items-center gap-2 ml-4">
+        <span className={label}>Label Mode</span>
+        <button
+          className={`${btn} ${labelMode === 'xyz' ? 'ring-2 ring-violet-400' : ''}`}
+          onClick={() => setLabelMode('xyz')}
+        >
+          XYZ
+        </button>
+        <button
+          className={`${btn} ${labelMode === 'face' ? 'ring-2 ring-violet-400' : ''}`}
+          onClick={() => setLabelMode('face')}
+        >
+          Face letters
+        </button>
+      </div>
+
+      <button className={`${btn} ml-2`} onClick={reset}>
+        Reset
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a shared React context for UI state
- restructure visualizer app into top bar, left controls, canvas, insights panel, and bottom strip
- expose scene and controls via store-driven components

## Testing
- `npm test`
- `dart test`


------
https://chatgpt.com/codex/tasks/task_e_689f0d346f54832eb4c8f24eeb4a065a