### PR TITLE
Add cube move engine and controls

### DIFF
--- a/visualizer/src/app/App.jsx
+++ b/visualizer/src/app/App.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { Canvas } from '@react-three/fiber';
 import { Scene } from '../components/Scene.jsx';
 import { StoreProvider } from './store.jsx';
@@ -8,15 +8,6 @@ import { Insights } from '../components/Insights.jsx';
 import { BottomStrip } from '../components/BottomStrip.jsx';
 
 export function App() {
-  const cubes = useMemo(() => {
-    const list = [];
-    let id = 0;
-    for (let x = -1; x <= 1; x++)
-      for (let y = -1; y <= 1; y++)
-        for (let z = -1; z <= 1; z++) list.push({ id: id++, pos: { x, y, z } });
-    return list;
-  }, []);
-
   return (
     <StoreProvider>
       <div className="w-full h-full grid grid-rows-[auto_1fr_auto] grid-cols-[auto_1fr_auto] bg-neutral-950 text-white">
@@ -28,7 +19,7 @@ export function App() {
         </div>
         <div className="row-start-2 col-start-2 relative">
           <Canvas camera={{ position: [5, 5, 6], fov: 45 }}>
-            <Scene cubes={cubes} />
+            <Scene />
           </Canvas>
         </div>
         <div className="row-start-2 col-start-3">

--- a/visualizer/src/app/store.jsx
+++ b/visualizer/src/app/store.jsx
@@ -1,9 +1,20 @@
 import React, { createContext, useContext, useState } from 'react';
 import { createPotts27 } from '../lib/potts27.js';
+import { applyFaceMove, applyMoves as applyMovesLib } from '../lib/moves.js';
 
 const StoreContext = createContext();
 
 export function StoreProvider({ children }) {
+  const makeCubes = () => {
+    const list = [];
+    let id = 0;
+    for (let x = -1; x <= 1; x++)
+      for (let y = -1; y <= 1; y++)
+        for (let z = -1; z <= 1; z++) list.push({ id: id++, pos: { x, y, z } });
+    return list;
+  };
+
+  const [cubes, setCubes] = useState(makeCubes());
   const [mode, setMode] = useState('exposure');
   const [alpha, setAlpha] = useState(1);
   const [tau0, setTau0] = useState(1);
@@ -18,6 +29,7 @@ export function StoreProvider({ children }) {
   const [isPottsRunning, setIsPottsRunning] = useState(false);
 
   const reset = () => {
+    setCubes(makeCubes());
     setMode('exposure');
     setAlpha(1);
     setTau0(1);
@@ -33,7 +45,14 @@ export function StoreProvider({ children }) {
     setPottsModel(createPotts27(3));
   };
 
+  const applyMove = (move) => setCubes(prev => applyFaceMove(prev, move));
+  const applyMoves = (seq) => setCubes(prev => applyMovesLib(prev, seq));
+  const invertMoves = (seq) =>
+    seq.slice().reverse().map(m => ({ face: m.face, quarterTurns: -m.quarterTurns }));
+
   const value = {
+    cubes,
+    setCubes,
     mode,
     setMode,
     alpha,
@@ -60,6 +79,9 @@ export function StoreProvider({ children }) {
     setIsPottsRunning,
     resetPotts,
     reset,
+    applyMove,
+    applyMoves,
+    invertMoves,
   };
 
   return <StoreContext.Provider value={value}>{children}</StoreContext.Provider>;

--- a/visualizer/src/components/Scene.jsx
+++ b/visualizer/src/components/Scene.jsx
@@ -8,8 +8,9 @@ import { Cubelet } from './Cubelet.jsx';
 import { useStore } from '../app/store.jsx';
 import { stepPotts27 } from '../lib/potts27.js';
 
-export function Scene({ cubes }) {
+export function Scene() {
   const {
+    cubes,
     drop,
     slice,
     showLabels,

--- a/visualizer/src/components/TopBar.jsx
+++ b/visualizer/src/components/TopBar.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { useStore } from '../app/store.jsx';
+import { Face } from '../lib/moves.js';
 
 export function TopBar() {
   const {
+    applyMove,
     mode,
     setMode,
     alpha,
@@ -129,6 +131,7 @@ export function TopBar() {
       <button className={`${btn} ml-2`} onClick={reset}>
         Reset
       </button>
+
       <div className="flex items-center gap-2 ml-4">
         <span className={label}>Temp</span>
         <input
@@ -150,6 +153,26 @@ export function TopBar() {
       <button className={`${btn} ml-2`} onClick={resetPotts}>
         Reset Potts
       </button>
+      <div className="ml-auto flex items-center gap-2">
+        <span className={label}>Moves</span>
+        {[
+          [Face.U, 'U', 1], [Face.U, "U'", -1], [Face.U, 'U2', 2],
+          [Face.R, 'R', 1], [Face.R, "R'", -1], [Face.R, 'R2', 2],
+          [Face.F, 'F', 1], [Face.F, "F'", -1], [Face.F, 'F2', 2],
+          [Face.D, 'D', 1], [Face.D, "D'", -1], [Face.D, 'D2', 2],
+          [Face.L, 'L', 1], [Face.L, "L'", -1], [Face.L, 'L2', 2],
+          [Face.B, 'B', 1], [Face.B, "B'", -1], [Face.B, 'B2', 2],
+        ].map(([face, labelText, q]) => (
+          <button
+            key={labelText + face}
+            className={btn}
+            onClick={() => applyMove({ face, quarterTurns: q })}
+            title={`${face} ${q === 2 ? '2' : q === -1 ? 'prime' : ''}`}
+          >
+            {labelText}
+          </button>
+        ))}
+      </div>
     </div>
   );
 }

--- a/visualizer/src/lib/moves.js
+++ b/visualizer/src/lib/moves.js
@@ -1,0 +1,57 @@
+// Right-hand-rule quarter turns matching the Dart impl:
+// rotateX: (x, y, z) -> (x, -z,  y)
+// rotateY: (x, y, z) -> (z,  y, -x)
+// rotateZ: (x, y, z) -> (-y, x,  z)
+
+export const Face = Object.freeze({ U: 'U', D: 'D', L: 'L', R: 'R', F: 'F', B: 'B' });
+
+export function rotateX({ x, y, z }) { return { x, y: -z, z:  y }; }
+export function rotateY({ x, y, z }) { return { x:  z, y, z: -x }; }
+export function rotateZ({ x, y, z }) { return { x: -y, y:  x, z }; }
+
+function mod4(q) { return ((q % 4) + 4) % 4; }
+
+function selectForFace(pos, face) {
+  switch (face) {
+    case Face.U: return pos.z ===  1;
+    case Face.D: return pos.z === -1;
+    case Face.R: return pos.x ===  1;
+    case Face.L: return pos.x === -1;
+    case Face.F: return pos.y ===  1;
+    case Face.B: return pos.y === -1;
+    default:     return false;
+  }
+}
+
+function rotorForFace(face) {
+  switch (face) {
+    case Face.U:
+    case Face.D:
+      return rotateZ;
+    case Face.R:
+    case Face.L:
+      return rotateX;
+    case Face.F:
+    case Face.B:
+      return rotateY;
+  }
+}
+
+// Apply one face move to an array of {id, pos:{x,y,z}}
+export function applyFaceMove(cubes, { face, quarterTurns }) {
+  const t = mod4(quarterTurns);
+  if (t === 0) return cubes;
+
+  const rot = rotorForFace(face);
+  return cubes.map(c => {
+    if (!selectForFace(c.pos, face)) return c;
+    let p = c.pos;
+    for (let i = 0; i < t; i++) p = rot(p);
+    return { ...c, pos: p };
+  });
+}
+
+// Convenience: apply a sequence [{face, quarterTurns}, ...]
+export function applyMoves(cubes, seq) {
+  return seq.reduce((acc, m) => applyFaceMove(acc, m), cubes);
+}


### PR DESCRIPTION
## Summary
- add a reusable move engine mirroring the right-hand-rule rotations from the Dart implementation
- lift cubelet positions into the global store with helpers for applying move sequences
- hook the scene and top bar into the new store data so the cube can perform face turns from the UI

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc46e029ac832ea8136e06c76b9dbd