### PR TITLE
Restore exposure and coupler colouring controls

### DIFF
--- a/visualizer/src/components/Cubelet.jsx
+++ b/visualizer/src/components/Cubelet.jsx
@@ -1,16 +1,41 @@
 import React, { useMemo } from 'react';
 import { NameSprite } from './NameSprite.jsx';
 import { useStore } from '../app/store.jsx';
+import { colorByExposure, colorByCoupler } from '../lib/colors.js';
+import { faceLetterFor } from '../lib/faces.js';
 import { stateSymbol, symbolColor } from '../lib/potts27.js';
 
-export function Cubelet({ pos, showNames, hidden, shared }) {
+export function Cubelet({
+  pos,
+  labelMode,
+  showNames,
+  hidden,
+  shared,
+  mode,
+  alpha,
+  tau0,
+}) {
   const spacing = 1.1;
   const size = 0.9;
   const { pottsModel } = useStore();
   const state = pottsModel.states[pos.x + 1][pos.y + 1][pos.z + 1];
-  const color = useMemo(() => symbolColor(state), [state]);
   const symbol = stateSymbol(state);
-  const textForSide = () => symbol;
+  const color = useMemo(() => {
+    if (mode === 'exposure') return colorByExposure(pos);
+    if (mode === 'coupler') return colorByCoupler(pos, alpha, tau0);
+    return symbolColor(state);
+  }, [mode, pos.x, pos.y, pos.z, alpha, tau0, state]);
+
+  const textForSide = (axis, sign) => {
+    if (labelMode === 'face') return faceLetterFor(pos, axis, sign);
+    if (labelMode === 'xyz') return `${pos.x},${pos.y},${pos.z}`;
+    return symbol;
+  };
+
+  const labelDeps =
+    labelMode === 'face' || labelMode === 'xyz'
+      ? labelMode
+      : `${labelMode ?? 'potts'}-${symbol}`;
 
   return (
     <group
@@ -26,7 +51,7 @@ export function Cubelet({ pos, showNames, hidden, shared }) {
           pos={pos}
           cubeSize={size}
           textForSide={textForSide}
-          depsKey={symbol}
+          depsKey={labelDeps}
         />
       ) : null}
     </group>

--- a/visualizer/src/components/Scene.jsx
+++ b/visualizer/src/components/Scene.jsx
@@ -11,6 +11,9 @@ import { stepPotts27 } from '../lib/potts27.js';
 export function Scene() {
   const {
     cubes,
+    mode,
+    alpha,
+    tau0,
     drop,
     slice,
     showLabels,
@@ -34,6 +37,9 @@ export function Scene() {
         showNames={showLabels}
         hidden={hidden}
         shared={shared}
+        mode={mode}
+        alpha={alpha}
+        tau0={tau0}
       />
     );
   };


### PR DESCRIPTION
## Summary
- pass the current color mode options and parameters from `Scene` into each `Cubelet`
- restore exposure and coupler driven colouring while retaining Potts colouring as a fallback
- respect the selected label mode when rendering name sprites so XYZ and face labels show correctly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd10e1647c832e8bae47642230c842