### PR TITLE
Remove manual move controls from visualizer

### DIFF
--- a/visualizer/src/app/store.jsx
+++ b/visualizer/src/app/store.jsx
@@ -1,6 +1,5 @@
 import React, { createContext, useContext, useState } from 'react';
 import { createPotts27 } from '../lib/potts27.js';
-import { applyFaceMove, applyMoves as applyMovesLib } from '../lib/moves.js';
 
 const StoreContext = createContext();
 
@@ -45,11 +44,6 @@ export function StoreProvider({ children }) {
     setPottsModel(createPotts27(3));
   };
 
-  const applyMove = (move) => setCubes(prev => applyFaceMove(prev, move));
-  const applyMoves = (seq) => setCubes(prev => applyMovesLib(prev, seq));
-  const invertMoves = (seq) =>
-    seq.slice().reverse().map(m => ({ face: m.face, quarterTurns: -m.quarterTurns }));
-
   const value = {
     cubes,
     setCubes,
@@ -79,9 +73,6 @@ export function StoreProvider({ children }) {
     setIsPottsRunning,
     resetPotts,
     reset,
-    applyMove,
-    applyMoves,
-    invertMoves,
   };
 
   return <StoreContext.Provider value={value}>{children}</StoreContext.Provider>;

--- a/visualizer/src/components/TopBar.jsx
+++ b/visualizer/src/components/TopBar.jsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import { useStore } from '../app/store.jsx';
-import { Face } from '../lib/moves.js';
 
 export function TopBar() {
   const {
-    applyMove,
     mode,
     setMode,
     alpha,
@@ -153,26 +151,6 @@ export function TopBar() {
       <button className={`${btn} ml-2`} onClick={resetPotts}>
         Reset Potts
       </button>
-      <div className="ml-auto flex items-center gap-2">
-        <span className={label}>Moves</span>
-        {[
-          [Face.U, 'U', 1], [Face.U, "U'", -1], [Face.U, 'U2', 2],
-          [Face.R, 'R', 1], [Face.R, "R'", -1], [Face.R, 'R2', 2],
-          [Face.F, 'F', 1], [Face.F, "F'", -1], [Face.F, 'F2', 2],
-          [Face.D, 'D', 1], [Face.D, "D'", -1], [Face.D, 'D2', 2],
-          [Face.L, 'L', 1], [Face.L, "L'", -1], [Face.L, 'L2', 2],
-          [Face.B, 'B', 1], [Face.B, "B'", -1], [Face.B, 'B2', 2],
-        ].map(([face, labelText, q]) => (
-          <button
-            key={labelText + face}
-            className={btn}
-            onClick={() => applyMove({ face, quarterTurns: q })}
-            title={`${face} ${q === 2 ? '2' : q === -1 ? 'prime' : ''}`}
-          >
-            {labelText}
-          </button>
-        ))}
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- remove the manual Rubik's cube move buttons from the visualizer top bar
- prune unused move helpers from the store context now that the controls are gone

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68cd13ccd4b4832eb3adbadec28cee51