### PR TITLE
feat: redesign visualizer ui with gamepad support

### DIFF
--- a/visualizer/package.json
+++ b/visualizer/package.json
@@ -16,6 +16,9 @@
     "three": "0.179.1"
   },
   "devDependencies": {
+    "@types/react": "^19.1.4",
+    "@types/react-dom": "^19.1.5",
+    "typescript": "^5.7.3",
     "vite": "^7.1.2",
     "vitest": "^1.1.3"
   }

--- a/visualizer/src/app/App.jsx
+++ b/visualizer/src/app/App.jsx
@@ -1,37 +1,69 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { Canvas } from '@react-three/fiber';
 import { Scene } from '../components/Scene.jsx';
-import { StoreProvider } from './store.jsx';
-import { TopBar } from '../components/TopBar.jsx';
-import { LeftControls } from '../components/LeftControls.jsx';
-import { Insights } from '../components/Insights.jsx';
-import { BottomStrip } from '../components/BottomStrip.jsx';
-import { useGamepad } from '../hooks/useGamepad.js';
+import { StoreProvider, useStore } from './store.jsx';
+import { AppBar } from '../components/AppBar.jsx';
+import { LeftDock } from '../components/LeftDock.jsx';
+import { StatusBar } from '../components/StatusBar.jsx';
+import { HudGamepad } from '../components/HudGamepad.jsx';
+import { CommandPalette } from '../components/CommandPalette.jsx';
+import { HelpOverlay } from '../components/HelpOverlay.jsx';
+import { SettingsModal } from '../components/SettingsModal.jsx';
+import { GamepadController } from '../components/GamepadController.jsx';
 
-export function App() {
-  useGamepad();
+function AppContent() {
+  const { ui, setUi, controller } = useStore();
+  const [gamepadStatus, setGamepadStatus] = useState(null);
+  const [intentHistory, setIntentHistory] = useState([]);
+  const [currentMapping, setCurrentMapping] = useState(controller.mapping);
+
+  const handleGamepadStatus = useCallback((status, history, mapping) => {
+    setGamepadStatus(status);
+    setIntentHistory(history);
+    setCurrentMapping(mapping);
+  }, []);
 
   return (
-    <StoreProvider>
-      <div className="w-full h-full grid grid-rows-[auto_1fr_auto] grid-cols-[auto_1fr_auto] bg-neutral-950 text-white">
-        <div className="row-start-1 col-span-3">
-          <TopBar />
+    <div className="relative w-full h-full bg-[#0b0b0f] text-white">
+      <GamepadController onStatus={handleGamepadStatus} />
+      <div className="absolute inset-0 grid grid-rows-[auto_1fr_auto] grid-cols-[auto_1fr]">
+        <div className="col-span-2">
+          <AppBar />
         </div>
         <div className="row-start-2 col-start-1">
-          <LeftControls />
+          <LeftDock />
         </div>
         <div className="row-start-2 col-start-2 relative">
           <Canvas camera={{ position: [5, 5, 6], fov: 45 }}>
             <Scene />
           </Canvas>
         </div>
-        <div className="row-start-2 col-start-3">
-          <Insights />
-        </div>
-        <div className="row-start-3 col-span-3">
-          <BottomStrip />
+        <div className="col-span-2">
+          <StatusBar gamepadStatus={gamepadStatus} />
         </div>
       </div>
+
+      <HudGamepad status={gamepadStatus} history={intentHistory} mapping={currentMapping} />
+
+      <CommandPalette
+        isOpen={ui.showPalette}
+        onClose={() => setUi({ showPalette: false })}
+        mapping={currentMapping}
+      />
+      <HelpOverlay
+        isOpen={ui.showHelp}
+        onClose={() => setUi({ showHelp: false })}
+        mapping={currentMapping}
+      />
+      <SettingsModal isOpen={ui.showSettings} onClose={() => setUi({ showSettings: false })} />
+    </div>
+  );
+}
+
+export function App() {
+  return (
+    <StoreProvider>
+      <AppContent />
     </StoreProvider>
   );
 }

--- a/visualizer/src/app/store.jsx
+++ b/visualizer/src/app/store.jsx
@@ -1,5 +1,43 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useEffect, useState } from 'react';
 import { createPotts27 } from '../lib/potts27.js';
+import { applyMoves } from '../lib/moves.js';
+import { IntentNames } from '../input/intents.ts';
+
+const STORAGE_KEY = 'livnium-visualizer-settings';
+
+const DEFAULT_CONTROLLER_MAPPING = {
+  [IntentNames.modeToggle]: { type: 'button', button: 'south' },
+  [IntentNames.pottsReset]: { type: 'button', button: 'east' },
+  [IntentNames.toggleLabels]: { type: 'button', button: 'west' },
+  [IntentNames.toggleAxes]: { type: 'button', button: 'north' },
+  [IntentNames.sliceDecrease]: { type: 'button', button: 'dpad-left', repeat: true },
+  [IntentNames.sliceIncrease]: { type: 'button', button: 'dpad-right', repeat: true },
+  [IntentNames.dropX]: { type: 'button', button: 'dpad-down' },
+  [IntentNames.dropY]: { type: 'button', button: 'dpad-up' },
+  [IntentNames.tauDecrease]: { type: 'button', button: 'l1', analog: false },
+  [IntentNames.tauIncrease]: { type: 'button', button: 'r1', analog: false },
+  [IntentNames.alphaDecrease]: { type: 'button', button: 'l2', analog: true },
+  [IntentNames.alphaIncrease]: { type: 'button', button: 'r2', analog: true },
+  [IntentNames.dropCycle]: { type: 'button', button: 'ls' },
+  [IntentNames.labelsCycle]: { type: 'button', button: 'rs' },
+  [IntentNames.openPalette]: { type: 'button', button: 'share' },
+  [IntentNames.pottsStart]: { type: 'button', button: 'options' },
+};
+
+const createDefaultControllerState = () => ({
+  mapping: { ...DEFAULT_CONTROLLER_MAPPING },
+  invertY: false,
+  deadzone: 0.2,
+});
+
+const DEFAULT_UI_STATE = {
+  leftDockOpen: true,
+  showHelp: false,
+  showPalette: false,
+  showSettings: false,
+  theme: 'dark',
+  fontScale: 1,
+};
 
 const StoreContext = createContext();
 
@@ -26,6 +64,112 @@ export function StoreProvider({ children }) {
   const [pottsModel, setPottsModel] = useState(createPotts27(3));
   const [temperature, setTemperature] = useState(1);
   const [isPottsRunning, setIsPottsRunning] = useState(false);
+  const [controller, setController] = useState(() => {
+    if (typeof window === 'undefined') return createDefaultControllerState();
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY);
+      if (!stored) return createDefaultControllerState();
+      const parsed = JSON.parse(stored);
+      return {
+        ...createDefaultControllerState(),
+        ...parsed.controller,
+        mapping: {
+          ...createDefaultControllerState().mapping,
+          ...(parsed.controller?.mapping ?? {}),
+        },
+      };
+    } catch (err) {
+      console.warn('Failed to load controller settings', err);
+      return createDefaultControllerState();
+    }
+  });
+  const [ui, setUi] = useState(() => {
+    if (typeof window === 'undefined') return { ...DEFAULT_UI_STATE };
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY);
+      if (!stored) return { ...DEFAULT_UI_STATE };
+      const parsed = JSON.parse(stored);
+      return { ...DEFAULT_UI_STATE, ...parsed.ui };
+    } catch (err) {
+      console.warn('Failed to load UI settings', err);
+      return { ...DEFAULT_UI_STATE };
+    }
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const payload = JSON.stringify({
+      controller: {
+        ...controller,
+        mapping: controller.mapping,
+      },
+      ui: {
+        leftDockOpen: ui.leftDockOpen,
+        showHelp: ui.showHelp,
+        showPalette: ui.showPalette,
+        showSettings: ui.showSettings,
+        theme: ui.theme,
+        fontScale: ui.fontScale,
+      },
+    });
+    window.localStorage.setItem(STORAGE_KEY, payload);
+  }, [controller, ui]);
+
+  const toggleMode = () => setMode((prev) => (prev === 'exposure' ? 'coupler' : 'exposure'));
+  const cycleLabelMode = () =>
+    setLabelMode((prev) => {
+      switch (prev) {
+        case 'xyz':
+          return 'face';
+        case 'face':
+          return 'base27';
+        default:
+          return 'xyz';
+      }
+    });
+  const cycleDrop = () =>
+    setDrop((prev) => {
+      switch (prev) {
+        case 'none':
+          return 'x';
+        case 'x':
+          return 'y';
+        case 'y':
+          return 'z';
+        default:
+          return 'none';
+      }
+    });
+  const clampSlice = (value) => Math.max(-1, Math.min(1, value));
+  const adjustSlice = (delta) => setSlice((prev) => clampSlice(prev + delta));
+  const adjustAlpha = (delta) => setAlpha((prev) => Math.max(0, Math.min(3, prev + delta)));
+  const adjustTau0 = (delta) => setTau0((prev) => Math.max(0.1, Math.min(2, prev + delta)));
+
+  const startPotts = () => setIsPottsRunning(true);
+  const stopPotts = () => setIsPottsRunning(false);
+  const togglePotts = () => setIsPottsRunning((prev) => !prev);
+
+  const applyMoveSequence = (sequence) => {
+    setCubes((prev) => applyMoves(prev, sequence));
+  };
+
+  const setControllerMapping = (intent, binding) => {
+    setController((prev) => ({
+      ...prev,
+      mapping: {
+        ...prev.mapping,
+        [intent]: binding,
+      },
+    }));
+  };
+
+  const resetControllerMapping = () => {
+    setController(createDefaultControllerState());
+  };
+
+  const setUiState = (partial) => {
+    setUi((prev) => ({ ...prev, ...partial }));
+  };
 
   const reset = () => {
     setCubes(makeCubes());
@@ -53,26 +197,47 @@ export function StoreProvider({ children }) {
     setAlpha,
     tau0,
     setTau0,
+    adjustAlpha,
+    adjustTau0,
     drop,
     setDrop,
     slice,
     setSlice,
+    adjustSlice,
+    cycleDrop,
     showLabels,
     setShowLabels,
+    toggleShowLabels: () => setShowLabels((prev) => !prev),
     labelMode,
     setLabelMode,
+    cycleLabelMode,
     selection,
     setSelection,
     showAxes,
     setShowAxes,
+    toggleShowAxes: () => setShowAxes((prev) => !prev),
     pottsModel,
     setPottsModel,
     temperature,
     setTemperature,
     isPottsRunning,
     setIsPottsRunning,
+    startPotts,
+    stopPotts,
+    togglePotts,
     resetPotts,
     reset,
+    controller,
+    setController,
+    setControllerMapping,
+    resetControllerMapping,
+    ui,
+    setUi: setUiState,
+    toggleMode,
+    cycleLabelMode,
+    cycleDrop,
+    adjustSlice,
+    applyMoveSequence,
   };
 
   return <StoreContext.Provider value={value}>{children}</StoreContext.Provider>;

--- a/visualizer/src/components/AppBar.jsx
+++ b/visualizer/src/components/AppBar.jsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { useStore } from '../app/store.jsx';
+
+function Chip({ active, children, onClick }) {
+  return (
+    <button
+      onClick={onClick}
+      className={`px-3 py-1 rounded-full text-sm transition-colors border ${
+        active ? 'bg-white/20 border-white/40 text-white' : 'bg-white/5 border-white/10 text-white/70'
+      } hover:bg-white/15`}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function AppBar() {
+  const {
+    mode,
+    setMode,
+    labelMode,
+    setLabelMode,
+    isPottsRunning,
+    startPotts,
+    stopPotts,
+    resetPotts,
+    setUi,
+  } = useStore();
+
+  const togglePotts = () => {
+    if (isPottsRunning) stopPotts();
+    else startPotts();
+  };
+
+  return (
+    <header className="h-14 flex items-center justify-between px-4 border-b border-white/10 bg-[#11131a]/95 backdrop-blur-sm">
+      <div className="flex items-center gap-3">
+        <div className="w-8 h-8 rounded bg-gradient-to-br from-emerald-400/80 to-cyan-500/60 flex items-center justify-center text-xs font-bold uppercase">
+          LV
+        </div>
+        <div>
+          <div className="text-sm uppercase tracking-[0.3em] text-white/60">Visualizer</div>
+          <div className="text-lg font-semibold text-white">Livnium Visualizer</div>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-4">
+        <div className="flex items-center gap-2">
+          <span className="text-xs uppercase tracking-wide text-white/50">Color</span>
+          <div className="flex gap-2">
+            <Chip active={mode === 'exposure'} onClick={() => setMode('exposure')}>
+              Exposure
+            </Chip>
+            <Chip active={mode === 'coupler'} onClick={() => setMode('coupler')}>
+              Coupler
+            </Chip>
+          </div>
+        </div>
+        <div className="h-8 w-px bg-white/10" />
+        <div className="flex items-center gap-2">
+          <span className="text-xs uppercase tracking-wide text-white/50">Labels</span>
+          <div className="flex gap-2">
+            {['xyz', 'face', 'base27'].map((option) => (
+              <Chip key={option} active={labelMode === option} onClick={() => setLabelMode(option)}>
+                {option.toUpperCase()}
+              </Chip>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <button
+          onClick={togglePotts}
+          className={`px-3 py-1.5 rounded-lg text-sm font-medium border transition ${
+            isPottsRunning
+              ? 'border-orange-400/60 text-orange-200 bg-orange-500/10'
+              : 'border-emerald-400/40 text-emerald-200 bg-emerald-500/10'
+          } hover:bg-white/10`}
+        >
+          {isPottsRunning ? 'Stop Potts' : 'Start Potts'}
+        </button>
+        <button
+          onClick={resetPotts}
+          className="px-3 py-1.5 rounded-lg text-sm font-medium border border-white/10 text-white/70 hover:text-white hover:bg-white/10"
+        >
+          Reset Potts
+        </button>
+        <button
+          onClick={() => setUi({ showHelp: true })}
+          className="w-9 h-9 rounded-full border border-white/20 text-white/80 hover:bg-white/10 flex items-center justify-center text-lg"
+          title="Help"
+        >
+          ?
+        </button>
+        <button
+          onClick={() => setUi({ showSettings: true })}
+          className="w-9 h-9 rounded-full border border-white/20 text-white/80 hover:bg-white/10 flex items-center justify-center"
+          title="Settings"
+        >
+          ⚙
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/visualizer/src/components/CommandPalette.jsx
+++ b/visualizer/src/components/CommandPalette.jsx
@@ -1,0 +1,124 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useStore } from '../app/store.jsx';
+import { listCommandEntries, IntentCatalog } from '../input/intents.ts';
+import { handleIntent, parseAlg } from '../input/intentHandlers.ts';
+
+const MOVE_COMMANDS = ['U', "U'", 'U2', 'D', "D'", 'D2', 'L', "L'", 'L2', 'R', "R'", 'R2', 'F', "F'", 'F2', 'B', "B'", 'B2'];
+
+const BUTTON_LABELS = {
+  south: 'A / Cross',
+  east: 'B / Circle',
+  west: 'X / Square',
+  north: 'Y / Triangle',
+  l1: 'L1',
+  r1: 'R1',
+  l2: 'L2',
+  r2: 'R2',
+  share: 'View / Share',
+  options: 'Menu / Options',
+  ls: 'LS Click',
+  rs: 'RS Click',
+  'dpad-up': 'D-Pad ↑',
+  'dpad-down': 'D-Pad ↓',
+  'dpad-left': 'D-Pad ←',
+  'dpad-right': 'D-Pad →',
+};
+
+export function CommandPalette({ isOpen, onClose, mapping }) {
+  const store = useStore();
+  const [query, setQuery] = useState('');
+  const commands = useMemo(() => {
+    const base = listCommandEntries();
+    const moves = MOVE_COMMANDS.map((move) => ({
+      id: `move:${move}`,
+      label: `Move ${move}`,
+      category: 'Moves',
+    }));
+    return [...base, ...moves];
+  }, []);
+
+  useEffect(() => {
+    const handler = (event) => {
+      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'k') {
+        event.preventDefault();
+        if (isOpen) onClose();
+        else store.setUi({ showPalette: true });
+      }
+      if (event.key === 'Escape' && isOpen) {
+        event.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [isOpen, onClose, store]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setQuery('');
+    }
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const filtered = commands.filter((cmd) => {
+    const value = `${cmd.label} ${cmd.category}`.toLowerCase();
+    return value.includes(query.toLowerCase());
+  });
+
+  const execute = (commandId) => {
+    if (commandId.startsWith('move:')) {
+      const seq = commandId.replace('move:', '');
+      store.applyMoveSequence(parseAlg(seq));
+      store.setUi({ showPalette: false });
+      return;
+    }
+    const intent = IntentCatalog[commandId];
+    if (intent) {
+      handleIntent(intent.create(), store);
+    }
+    store.setUi({ showPalette: false });
+  };
+
+  return (
+    <div className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm flex items-start justify-center pt-24" role="dialog" aria-modal>
+      <div className="w-[520px] bg-[#11131a] border border-white/10 rounded-xl shadow-xl overflow-hidden">
+        <div className="border-b border-white/10">
+          <input
+            autoFocus
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search commands..."
+            className="w-full px-4 py-3 bg-transparent text-white outline-none"
+          />
+        </div>
+        <div className="max-h-80 overflow-y-auto">
+          {filtered.length === 0 ? (
+            <div className="px-4 py-8 text-sm text-white/50">No commands found.</div>
+          ) : (
+            filtered.map((cmd) => {
+              const binding = mapping?.[cmd.id];
+              return (
+                <button
+                  key={cmd.id}
+                  onClick={() => execute(cmd.id)}
+                  className="w-full text-left px-4 py-3 hover:bg-white/10 transition flex items-center justify-between text-white/80"
+                >
+                  <div>
+                    <div className="text-sm text-white">{cmd.label}</div>
+                    <div className="text-xs text-white/50">{cmd.category}</div>
+                  </div>
+                  {binding && binding.type === 'button' && (
+                    <span className="text-xs text-white/60 border border-white/10 rounded px-2 py-1">
+                      {BUTTON_LABELS[binding.button] ?? binding.button}
+                    </span>
+                  )}
+                </button>
+              );
+            })
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/visualizer/src/components/GamepadController.jsx
+++ b/visualizer/src/components/GamepadController.jsx
@@ -1,0 +1,41 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useGamepadIntents } from '../input/gamepad.ts';
+import { handleIntent } from '../input/intentHandlers.ts';
+import { useStore } from '../app/store.jsx';
+
+const MAX_HISTORY = 5;
+
+export function GamepadController({ onStatus }) {
+  const store = useStore();
+  const [history, setHistory] = useState([]);
+
+  const mapping = useMemo(() => store.controller?.mapping ?? {}, [store.controller]);
+
+  const status = useGamepadIntents(
+    useCallback(
+      (intent, intentName) => {
+        handleIntent(intent, store);
+        setHistory((prev) => {
+          const entry = {
+            name: intentName,
+            intent,
+            at: Date.now(),
+          };
+          const next = [...prev, entry];
+          if (next.length > MAX_HISTORY) next.shift();
+          return next;
+        });
+      },
+      [store]
+    ),
+    mapping
+  );
+
+  useEffect(() => {
+    if (onStatus) {
+      onStatus(status, history, mapping);
+    }
+  }, [onStatus, status, history, mapping]);
+
+  return null;
+}

--- a/visualizer/src/components/HelpOverlay.jsx
+++ b/visualizer/src/components/HelpOverlay.jsx
@@ -1,0 +1,120 @@
+import React, { useEffect } from 'react';
+import { useStore } from '../app/store.jsx';
+import { IntentCatalog } from '../input/intents.ts';
+
+const KEYBOARD_EQUIVALENTS = [
+  { action: 'Toggle Mode', key: '1' },
+  { action: 'Slice Left/Right', key: 'L / R' },
+  { action: 'Drop Axis', key: 'X / Y / Z / 0' },
+  { action: 'Alpha ±', key: '[ / ]' },
+  { action: 'Tau₀ ±', key: "; / '" },
+  { action: 'Start/Stop Potts', key: 'Space' },
+  { action: 'Reset Potts', key: 'B' },
+  { action: 'Help', key: '?' },
+];
+
+const BUTTON_LABELS = {
+  south: 'A / Cross',
+  east: 'B / Circle',
+  west: 'X / Square',
+  north: 'Y / Triangle',
+  l1: 'L1',
+  r1: 'R1',
+  l2: 'L2',
+  r2: 'R2',
+  share: 'View / Share',
+  options: 'Menu / Options',
+  ls: 'LS Click',
+  rs: 'RS Click',
+  'dpad-up': 'D-Pad ↑',
+  'dpad-down': 'D-Pad ↓',
+  'dpad-left': 'D-Pad ←',
+  'dpad-right': 'D-Pad →',
+};
+
+export function HelpOverlay({ isOpen, onClose, mapping }) {
+  const { resetControllerMapping } = useStore();
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (event) => {
+      if (event.key === 'Escape' || event.key.toLowerCase() === 'b') {
+        event.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const entries = Object.entries(mapping ?? {}).map(([intentName, binding]) => {
+    const intent = IntentCatalog[intentName];
+    if (!intent) return null;
+    return {
+      label: intent.label,
+      binding: binding?.type === 'button' ? BUTTON_LABELS[binding.button] ?? binding.button : '—',
+    };
+  }).filter(Boolean);
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/80 backdrop-blur-md text-white overflow-auto">
+      <div className="max-w-5xl mx-auto py-16 px-8 space-y-10">
+        <div className="flex items-start justify-between">
+          <div>
+            <h1 className="text-3xl font-semibold">Control Reference</h1>
+            <p className="text-white/70 max-w-xl mt-2">
+              Livnium Visualizer is fully navigable with DualSense and Xbox controllers. Use this guide to learn the default
+              bindings and keyboard equivalents. You can remap buttons in Settings.
+            </p>
+          </div>
+          <button onClick={onClose} className="text-white/70 hover:text-white text-xl">×</button>
+        </div>
+
+        <section className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div className="bg-white/5 rounded-xl border border-white/10 p-6">
+            <h2 className="text-lg font-semibold mb-4">Controller Bindings</h2>
+            <div className="space-y-2 text-sm">
+              {entries.length === 0 && <div className="text-white/50">No bindings configured.</div>}
+              {entries.map((entry) => (
+                <div key={entry.label} className="flex items-center justify-between bg-black/30 px-3 py-2 rounded">
+                  <span>{entry.label}</span>
+                  <span className="text-white/60">{entry.binding}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="bg-white/5 rounded-xl border border-white/10 p-6">
+            <h2 className="text-lg font-semibold mb-4">Keyboard Equivalents</h2>
+            <div className="space-y-2 text-sm">
+              {KEYBOARD_EQUIVALENTS.map((item) => (
+                <div key={item.action} className="flex items-center justify-between bg-black/30 px-3 py-2 rounded">
+                  <span>{item.action}</span>
+                  <span className="text-white/60">{item.key}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <div className="flex items-center justify-between bg-white/5 border border-white/10 rounded-xl p-6">
+          <div>
+            <h3 className="text-lg font-semibold">Reset bindings</h3>
+            <p className="text-white/60 max-w-lg">Return controller mappings to their defaults. This keeps other settings intact.</p>
+          </div>
+          <button
+            onClick={() => {
+              resetControllerMapping();
+              onClose();
+            }}
+            className="px-4 py-2 rounded-lg border border-white/20 bg-white/10 hover:bg-white/20"
+          >
+            Reset to defaults
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/visualizer/src/components/HudGamepad.jsx
+++ b/visualizer/src/components/HudGamepad.jsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { IntentCatalog } from '../input/intents.ts';
+
+const BUTTON_LABELS = {
+  south: 'A / Cross',
+  east: 'B / Circle',
+  west: 'X / Square',
+  north: 'Y / Triangle',
+  l1: 'L1',
+  r1: 'R1',
+  l2: 'L2',
+  r2: 'R2',
+  share: 'View / Share',
+  options: 'Menu / Options',
+  ls: 'LS Click',
+  rs: 'RS Click',
+  'dpad-up': 'D-Pad ↑',
+  'dpad-down': 'D-Pad ↓',
+  'dpad-left': 'D-Pad ←',
+  'dpad-right': 'D-Pad →',
+};
+
+function formatTime(timestamp) {
+  const date = new Date(timestamp);
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+export function HudGamepad({ status, history, mapping }) {
+  const connected = status?.connected;
+  const id = status?.id ?? 'No controller';
+  const axes = status?.axes ?? [];
+
+  const legend = Object.entries(mapping ?? {}).map(([intentName, binding]) => {
+    const intent = IntentCatalog[intentName];
+    if (!intent || binding.type !== 'button') return null;
+    return {
+      intent,
+      binding,
+    };
+  }).filter(Boolean);
+
+  return (
+    <div className="pointer-events-none fixed bottom-4 right-4 w-80 bg-black/60 border border-white/10 rounded-xl p-4 text-white/80 space-y-3 shadow-xl backdrop-blur">
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="text-xs uppercase tracking-wide text-white/50">Gamepad</div>
+          <div className="text-sm font-medium text-white/90">{connected ? id : 'Disconnected'}</div>
+        </div>
+        <div className={`text-xs px-2 py-0.5 rounded-full ${connected ? 'bg-emerald-500/20 text-emerald-200' : 'bg-red-500/20 text-red-200'}`}>
+          {connected ? 'Connected' : 'Waiting'}
+        </div>
+      </div>
+
+      <div>
+        <div className="text-xs uppercase tracking-wide text-white/50 mb-1">Last Intents</div>
+        <div className="space-y-1 text-xs">
+          {history && history.length > 0 ? (
+            [...history]
+              .slice()
+              .reverse()
+              .map((entry) => {
+                const intent = IntentCatalog[entry.name];
+                return (
+                  <div key={entry.at} className="flex items-center justify-between bg-white/5 px-2 py-1 rounded">
+                    <span>{intent ? intent.label : entry.name}</span>
+                    <span className="text-white/50">{formatTime(entry.at)}</span>
+                  </div>
+                );
+              })
+          ) : (
+            <div className="text-white/40">Interact with the controller to see activity.</div>
+          )}
+        </div>
+      </div>
+
+      <div>
+        <div className="text-xs uppercase tracking-wide text-white/50 mb-1">Axes</div>
+        <div className="text-xs grid grid-cols-2 gap-1">
+          {axes.slice(0, 4).map((value, index) => (
+            <div key={index} className="bg-white/5 px-2 py-1 rounded flex justify-between">
+              <span>Axis {index}</span>
+              <span className="text-white/60">{value.toFixed(2)}</span>
+            </div>
+          ))}
+          {axes.length === 0 && <div className="text-white/40 col-span-2">No axes detected</div>}
+        </div>
+      </div>
+
+      <div>
+        <div className="text-xs uppercase tracking-wide text-white/50 mb-1">Legend</div>
+        <div className="grid grid-cols-2 gap-2 text-[11px]">
+          {legend.length > 0 ? (
+            legend.slice(0, 8).map(({ intent, binding }) => (
+              <div key={intent.id} className="bg-white/5 px-2 py-1 rounded">
+                <div className="text-white/60">{BUTTON_LABELS[binding.button] ?? binding.button}</div>
+                <div className="text-white/90 font-medium">{intent.label}</div>
+              </div>
+            ))
+          ) : (
+            <div className="text-white/40 col-span-2">Configure mappings in Settings.</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/visualizer/src/components/LeftDock.jsx
+++ b/visualizer/src/components/LeftDock.jsx
@@ -1,0 +1,171 @@
+import React from 'react';
+import { useStore } from '../app/store.jsx';
+import { parseAlg } from '../input/intentHandlers.ts';
+
+const dropOptions = [
+  { label: 'None', value: 'none' },
+  { label: 'X', value: 'x' },
+  { label: 'Y', value: 'y' },
+  { label: 'Z', value: 'z' },
+];
+
+const moves = ['U', "U'", 'U2', 'D', "D'", 'D2', 'L', "L'", 'L2', 'R', "R'", 'R2', 'F', "F'", 'F2', 'B', "B'", 'B2'];
+
+export function LeftDock() {
+  const {
+    drop,
+    setDrop,
+    slice,
+    setSlice,
+    alpha,
+    setAlpha,
+    tau0,
+    setTau0,
+    temperature,
+    setTemperature,
+    showLabels,
+    setShowLabels,
+    showAxes,
+    setShowAxes,
+    applyMoveSequence,
+    ui,
+    setUi,
+  } = useStore();
+
+  const collapsed = !ui.leftDockOpen;
+
+  return (
+    <aside
+      className={`h-full transition-all duration-200 ${
+        collapsed ? 'w-12' : 'w-72'
+      } border-r border-white/10 bg-[#0f1118]/95 backdrop-blur-sm flex flex-col`}
+    >
+      <div className="flex items-center justify-between px-3 py-2 border-b border-white/5 text-xs uppercase tracking-wide text-white/50">
+        Controls
+        <button
+          className="text-white/70 hover:text-white"
+          onClick={() => setUi({ leftDockOpen: collapsed })}
+        >
+          {collapsed ? '»' : '«'}
+        </button>
+      </div>
+      {!collapsed && (
+        <div className="flex-1 overflow-y-auto p-4 space-y-6 text-white/80">
+          <section>
+            <h2 className="text-xs uppercase tracking-wide text-white/50 mb-2">Drop Axis</h2>
+            <div className="grid grid-cols-2 gap-2">
+              {dropOptions.map((opt) => (
+                <button
+                  key={opt.value}
+                  onClick={() => setDrop(opt.value)}
+                  className={`px-3 py-2 rounded-lg border text-sm transition ${
+                    drop === opt.value
+                      ? 'border-sky-400/70 text-sky-200 bg-sky-500/10'
+                      : 'border-white/10 text-white/70 hover:text-white hover:bg-white/10'
+                  }`}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          </section>
+
+          <section>
+            <h2 className="text-xs uppercase tracking-wide text-white/50 mb-2">Slice</h2>
+            <div className="flex items-center gap-2">
+              {[-1, 0, 1].map((value) => (
+                <button
+                  key={value}
+                  onClick={() => setSlice(value)}
+                  className={`px-3 py-2 rounded-lg border text-sm transition ${
+                    slice === value
+                      ? 'border-emerald-400/70 text-emerald-200 bg-emerald-500/10'
+                      : 'border-white/10 text-white/70 hover:text-white hover:bg-white/10'
+                  }`}
+                >
+                  {value}
+                </button>
+              ))}
+            </div>
+          </section>
+
+          <section className="space-y-4">
+            <div>
+              <header className="flex items-center justify-between text-xs uppercase tracking-wide text-white/50">
+                <span>Alpha</span>
+                <span className="text-white/70">{alpha.toFixed(2)}</span>
+              </header>
+              <input
+                type="range"
+                min={0}
+                max={3}
+                step={0.05}
+                value={alpha}
+                onChange={(e) => setAlpha(parseFloat(e.target.value))}
+                className="w-full"
+              />
+            </div>
+            <div>
+              <header className="flex items-center justify-between text-xs uppercase tracking-wide text-white/50">
+                <span>Tau₀</span>
+                <span className="text-white/70">{tau0.toFixed(2)}</span>
+              </header>
+              <input
+                type="range"
+                min={0.1}
+                max={2}
+                step={0.05}
+                value={tau0}
+                onChange={(e) => setTau0(parseFloat(e.target.value))}
+                className="w-full"
+              />
+            </div>
+            <div>
+              <header className="flex items-center justify-between text-xs uppercase tracking-wide text-white/50">
+                <span>Temperature</span>
+                <span className="text-white/70">{temperature.toFixed(2)}</span>
+              </header>
+              <input
+                type="range"
+                min={0.1}
+                max={3}
+                step={0.05}
+                value={temperature}
+                onChange={(e) => setTemperature(parseFloat(e.target.value))}
+                className="w-full"
+              />
+            </div>
+          </section>
+
+          <section>
+            <h2 className="text-xs uppercase tracking-wide text-white/50 mb-2">View</h2>
+            <div className="space-y-2">
+              <label className="flex items-center gap-2 text-sm">
+                <input type="checkbox" checked={showLabels} onChange={(e) => setShowLabels(e.target.checked)} />
+                Show Labels
+              </label>
+              <label className="flex items-center gap-2 text-sm">
+                <input type="checkbox" checked={showAxes} onChange={(e) => setShowAxes(e.target.checked)} /> Show Axes
+              </label>
+            </div>
+          </section>
+
+          <section>
+            <h2 className="text-xs uppercase tracking-wide text-white/50 mb-2">Moves</h2>
+            <div className="grid grid-cols-3 gap-2">
+              {moves.map((move) => (
+                <button
+                  key={move}
+                  onClick={() => applyMoveSequence(parseAlg(move))}
+                  className="px-2 py-2 rounded-lg border border-white/10 text-sm text-white/70 hover:text-white hover:bg-white/10"
+                >
+                  {move}
+                </button>
+              ))}
+            </div>
+          </section>
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/visualizer/src/components/SettingsModal.jsx
+++ b/visualizer/src/components/SettingsModal.jsx
@@ -1,0 +1,201 @@
+import React, { useState, useEffect } from 'react';
+import { useStore } from '../app/store.jsx';
+import { IntentCatalog, IntentNames } from '../input/intents.ts';
+
+const BUTTON_OPTIONS = [
+  { value: 'south', label: 'A / Cross' },
+  { value: 'east', label: 'B / Circle' },
+  { value: 'west', label: 'X / Square' },
+  { value: 'north', label: 'Y / Triangle' },
+  { value: 'l1', label: 'L1' },
+  { value: 'r1', label: 'R1' },
+  { value: 'l2', label: 'L2' },
+  { value: 'r2', label: 'R2' },
+  { value: 'ls', label: 'LS Click' },
+  { value: 'rs', label: 'RS Click' },
+  { value: 'share', label: 'View / Share' },
+  { value: 'options', label: 'Menu / Options' },
+  { value: 'dpad-up', label: 'D-Pad ↑' },
+  { value: 'dpad-down', label: 'D-Pad ↓' },
+  { value: 'dpad-left', label: 'D-Pad ←' },
+  { value: 'dpad-right', label: 'D-Pad →' },
+];
+
+const TABS = [
+  { id: 'controller', label: 'Controller' },
+  { id: 'display', label: 'Display' },
+];
+
+export function SettingsModal({ isOpen, onClose }) {
+  const store = useStore();
+  const { controller, setControllerMapping, setController, ui, setUi } = store;
+  const [activeTab, setActiveTab] = useState('controller');
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (event) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [isOpen, onClose]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setActiveTab('controller');
+    }
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const mapping = controller?.mapping ?? {};
+
+  const handleBindingChange = (intentName, value) => {
+    if (!value) {
+      setController((prev) => {
+        const nextMapping = { ...prev.mapping };
+        delete nextMapping[intentName];
+        return { ...prev, mapping: nextMapping };
+      });
+      return;
+    }
+    const current = mapping[intentName] ?? { type: 'button', button: value };
+    setControllerMapping(intentName, { ...current, button: value });
+  };
+
+  const renderControllerTab = () => {
+    const entries = Object.entries(IntentCatalog).filter(([id]) => id !== IntentNames.openPalette && id !== IntentNames.toggleHelp);
+
+    return (
+      <div className="space-y-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {entries.map(([id, intent]) => {
+            const binding = mapping[id];
+            return (
+              <div key={id} className="bg-white/5 border border-white/10 rounded-lg p-4">
+                <div className="text-sm text-white/80">{intent.label}</div>
+                <div className="text-xs text-white/40 mb-2">{intent.category}</div>
+                <select
+                  value={binding?.button ?? ''}
+                  onChange={(e) => handleBindingChange(id, e.target.value)}
+                  className="w-full bg-black/40 border border-white/20 rounded px-2 py-1 text-white"
+                >
+                  <option value="">Unassigned</option>
+                  {BUTTON_OPTIONS.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="bg-white/5 border border-white/10 rounded-lg p-4 space-y-2">
+            <div className="text-sm text-white/80">Deadzone</div>
+            <input
+              type="range"
+              min={0}
+              max={0.5}
+              step={0.01}
+              value={controller.deadzone}
+              onChange={(e) => setController((prev) => ({ ...prev, deadzone: parseFloat(e.target.value) }))}
+              className="w-full"
+            />
+            <div className="text-xs text-white/50">{controller.deadzone.toFixed(2)}</div>
+          </div>
+          <div className="bg-white/5 border border-white/10 rounded-lg p-4 flex items-center justify-between">
+            <div>
+              <div className="text-sm text-white/80">Invert Y Axis</div>
+              <div className="text-xs text-white/50">Swap the sign of vertical look input</div>
+            </div>
+            <label className="inline-flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={controller.invertY}
+                onChange={(e) => setController((prev) => ({ ...prev, invertY: e.target.checked }))}
+              />
+              Invert
+            </label>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  const renderDisplayTab = () => (
+    <div className="space-y-4">
+      <div className="bg-white/5 border border-white/10 rounded-lg p-4 flex items-center justify-between">
+        <div>
+          <div className="text-sm text-white/80">Theme</div>
+          <div className="text-xs text-white/50">Dark theme is recommended for accuracy.</div>
+        </div>
+        <select
+          value={ui.theme}
+          onChange={(e) => setUi({ theme: e.target.value })}
+          className="bg-black/40 border border-white/20 rounded px-3 py-1 text-white"
+        >
+          <option value="dark">Dark</option>
+          <option value="light">Light</option>
+        </select>
+      </div>
+      <div className="bg-white/5 border border-white/10 rounded-lg p-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <div className="text-sm text-white/80">Font Scale</div>
+            <div className="text-xs text-white/50">Adjust UI readability for streaming or presentations.</div>
+          </div>
+          <span className="text-white/60">{ui.fontScale.toFixed(2)}x</span>
+        </div>
+        <input
+          type="range"
+          min={0.8}
+          max={1.4}
+          step={0.05}
+          value={ui.fontScale}
+          onChange={(e) => setUi({ fontScale: parseFloat(e.target.value) })}
+          className="w-full mt-3"
+        />
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm flex items-center justify-center">
+      <div className="w-[720px] max-h-[80vh] bg-[#11131a] border border-white/10 rounded-2xl overflow-hidden shadow-2xl">
+        <header className="flex items-center justify-between px-6 py-4 border-b border-white/10">
+          <div>
+            <h2 className="text-xl font-semibold text-white">Settings</h2>
+            <p className="text-white/50 text-sm">Customize controller bindings and display preferences.</p>
+          </div>
+          <button onClick={onClose} className="text-white/60 hover:text-white text-xl">×</button>
+        </header>
+        <div className="px-6 pt-4">
+          <div className="flex gap-2">
+            {TABS.map((tab) => (
+              <button
+                key={tab.id}
+                onClick={() => setActiveTab(tab.id)}
+                className={`px-4 py-2 rounded-full text-sm border ${
+                  activeTab === tab.id
+                    ? 'border-white/40 bg-white/20 text-white'
+                    : 'border-white/10 bg-white/5 text-white/60 hover:text-white'
+                }`}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="px-6 py-6 overflow-y-auto max-h-[60vh]">
+          {activeTab === 'controller' ? renderControllerTab() : renderDisplayTab()}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/visualizer/src/components/StatusBar.jsx
+++ b/visualizer/src/components/StatusBar.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { useStore } from '../app/store.jsx';
+
+export function StatusBar({ gamepadStatus }) {
+  const { mode, labelMode, drop, slice, temperature, isPottsRunning } = useStore();
+  const connected = gamepadStatus?.connected;
+
+  return (
+    <footer className="h-12 flex items-center justify-between px-4 border-t border-white/10 bg-[#11131a]/90 text-white/70 text-sm">
+      <div className="flex items-center gap-4">
+        <span>
+          Mode:
+          <strong className="ml-1 text-white">{mode === 'exposure' ? 'Exposure' : 'Coupler'}</strong>
+        </span>
+        <span>
+          Labels:
+          <strong className="ml-1 text-white">{labelMode.toUpperCase()}</strong>
+        </span>
+        <span>
+          Drop:
+          <strong className="ml-1 text-white">{drop === 'none' ? 'None' : drop.toUpperCase()}</strong>
+        </span>
+        <span>
+          Slice:
+          <strong className="ml-1 text-white">{slice}</strong>
+        </span>
+      </div>
+      <div className="text-white/80">
+        Potts: {isPottsRunning ? 'Running' : 'Stopped'} · Temp {temperature.toFixed(2)}
+      </div>
+      <div className="flex items-center gap-2">
+        <span className={`w-2 h-2 rounded-full ${connected ? 'bg-emerald-400' : 'bg-red-400'}`} />
+        <span>{connected ? 'Controller Connected' : 'No Controller'}</span>
+      </div>
+    </footer>
+  );
+}

--- a/visualizer/src/input/gamepad.ts
+++ b/visualizer/src/input/gamepad.ts
@@ -1,0 +1,188 @@
+import { useEffect, useRef, useState } from 'react';
+import { createIntentFromName } from './intents.ts';
+
+export type Intent =
+  | { type: 'mode/toggle' }
+  | { type: 'labels/cycle' }
+  | { type: 'drop/set'; axis: 'none' | 'x' | 'y' | 'z' }
+  | { type: 'drop/cycle' }
+  | { type: 'slice/inc'; delta: -1 | 1 }
+  | { type: 'param/alpha'; delta: number }
+  | { type: 'param/tau0'; delta: number }
+  | { type: 'potts/start' }
+  | { type: 'potts/stop' }
+  | { type: 'potts/reset' }
+  | { type: 'view/toggleAxes' }
+  | { type: 'view/toggleLabels' }
+  | { type: 'move'; seq: string }
+  | { type: 'ui/togglePalette'; value?: boolean }
+  | { type: 'ui/toggleHelp'; value?: boolean };
+
+export type ButtonName =
+  | 'south'
+  | 'east'
+  | 'west'
+  | 'north'
+  | 'l1'
+  | 'r1'
+  | 'l2'
+  | 'r2'
+  | 'share'
+  | 'options'
+  | 'ls'
+  | 'rs'
+  | 'dpad-up'
+  | 'dpad-down'
+  | 'dpad-left'
+  | 'dpad-right';
+
+export type ButtonBinding = {
+  type: 'button';
+  button: ButtonName;
+  repeat?: boolean;
+  analog?: boolean;
+};
+
+export type ControllerMapping = Record<string, ButtonBinding>;
+
+export type GamepadStatus = {
+  connected: boolean;
+  id?: string;
+  buttons: boolean[];
+  axes: number[];
+};
+
+type RepeatState = {
+  active: boolean;
+  nextFire: number;
+};
+
+const LAYOUTS: Record<string, Record<ButtonName, number[]>> = {
+  standard: {
+    south: [0],
+    east: [1],
+    west: [2],
+    north: [3],
+    l1: [4],
+    r1: [5],
+    l2: [6],
+    r2: [7],
+    share: [8, 16],
+    options: [9],
+    ls: [10],
+    rs: [11],
+    'dpad-up': [12],
+    'dpad-down': [13],
+    'dpad-left': [14],
+    'dpad-right': [15],
+  },
+  dualsense: {
+    south: [0],
+    east: [1],
+    west: [2],
+    north: [3],
+    l1: [4],
+    r1: [5],
+    l2: [6],
+    r2: [7],
+    share: [8],
+    options: [9],
+    ls: [10],
+    rs: [11],
+    'dpad-up': [12],
+    'dpad-down': [13],
+    'dpad-left': [14],
+    'dpad-right': [15],
+  },
+};
+
+function detectLayout(id: string) {
+  const lowered = id.toLowerCase();
+  if (lowered.includes('dual')) return 'dualsense';
+  return 'standard';
+}
+
+function getButtonsFor(layout: string, button: ButtonName): number[] {
+  const source = LAYOUTS[layout] ?? LAYOUTS.standard;
+  return source[button] ?? [];
+}
+
+export function useGamepadIntents(
+  onIntent: (intent: Intent, intentName: string) => void,
+  mapping: ControllerMapping
+): GamepadStatus {
+  const [status, setStatus] = useState<GamepadStatus>({ connected: false, buttons: [], axes: [] });
+  const onIntentRef = useRef(onIntent);
+  const mappingRef = useRef(mapping);
+  const repeatRef = useRef<Record<string, RepeatState>>({});
+  const prevPressedRef = useRef<Record<string, boolean>>({});
+
+  useEffect(() => {
+    onIntentRef.current = onIntent;
+  }, [onIntent]);
+
+  useEffect(() => {
+    mappingRef.current = mapping;
+  }, [mapping]);
+
+  useEffect(() => {
+    let raf: number;
+
+    const fireIntent = (intentName: string, analogValue: number) => {
+      const intent = createIntentFromName(intentName, { analogValue });
+      if (intent) onIntentRef.current(intent, intentName);
+    };
+
+    const step = () => {
+      const pads = navigator.getGamepads ? navigator.getGamepads() : [];
+      const pad = pads.find((p): p is Gamepad => Boolean(p));
+
+      if (!pad) {
+        setStatus((prev) => (prev.connected ? { connected: false, buttons: [], axes: [] } : prev));
+        prevPressedRef.current = {};
+        repeatRef.current = {};
+      } else {
+        const layout = detectLayout(pad.id);
+        const buttonsPressed = pad.buttons.map((b) => b.pressed);
+        const axesValues = Array.from(pad.axes);
+        setStatus({ connected: true, id: pad.id, buttons: buttonsPressed, axes: axesValues });
+
+        const now = performance.now();
+        for (const [intentName, binding] of Object.entries(mappingRef.current)) {
+          if (!binding || binding.type !== 'button') continue;
+          const indices = getButtonsFor(layout, binding.button);
+          if (!indices.length) continue;
+          const pressed = indices.some((idx) => pad.buttons[idx]?.pressed ?? false);
+          const analogValue = binding.analog
+            ? Math.max(...indices.map((idx) => pad.buttons[idx]?.value ?? 0))
+            : 1;
+          const prevPressed = prevPressedRef.current[intentName] ?? false;
+          const repeatState = repeatRef.current[intentName] ?? { active: false, nextFire: 0 };
+
+          if (pressed && !prevPressed) {
+            fireIntent(intentName, analogValue);
+            repeatRef.current[intentName] = {
+              active: Boolean(binding.repeat),
+              nextFire: now + (binding.repeat ? 250 : Number.POSITIVE_INFINITY),
+            };
+          } else if (!pressed && prevPressed) {
+            repeatRef.current[intentName] = { active: Boolean(binding.repeat), nextFire: 0 };
+          } else if (pressed && binding.repeat && repeatState.active && now >= repeatState.nextFire) {
+            fireIntent(intentName, analogValue);
+            repeatState.nextFire = now + 100;
+            repeatRef.current[intentName] = repeatState;
+          }
+
+          prevPressedRef.current[intentName] = pressed;
+        }
+      }
+
+      raf = requestAnimationFrame(step);
+    };
+
+    raf = requestAnimationFrame(step);
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  return status;
+}

--- a/visualizer/src/input/intentHandlers.ts
+++ b/visualizer/src/input/intentHandlers.ts
@@ -1,0 +1,111 @@
+import type { Intent } from './gamepad';
+import { Face } from '../lib/moves.js';
+
+type StoreLike = {
+  mode: string;
+  toggleMode: () => void;
+  cycleLabelMode: () => void;
+  setDrop: (axis: 'none' | 'x' | 'y' | 'z') => void;
+  drop: 'none' | 'x' | 'y' | 'z';
+  adjustSlice: (delta: number) => void;
+  adjustAlpha: (delta: number) => void;
+  adjustTau0: (delta: number) => void;
+  startPotts: () => void;
+  stopPotts: () => void;
+  resetPotts: () => void;
+  isPottsRunning: boolean;
+  toggleShowAxes: () => void;
+  toggleShowLabels: () => void;
+  applyMoveSequence: (sequence: Array<{ face: string; quarterTurns: number }>) => void;
+  setUi: (ui: Partial<{ leftDockOpen: boolean; showHelp: boolean; showPalette: boolean; showSettings: boolean; theme: string; fontScale: number }>) => void;
+  ui: {
+    showPalette: boolean;
+    showHelp: boolean;
+  };
+};
+
+export function parseAlg(text: string) {
+  if (!text) return [];
+  const tokens = text
+    .split(/\s+/)
+    .map((t) => t.trim())
+    .filter(Boolean);
+  const moves: Array<{ face: string; quarterTurns: number }> = [];
+
+  for (const token of tokens) {
+    const match = token.match(/^([UDLRFB])([2']?)$/i);
+    if (!match) continue;
+    const face = match[1].toUpperCase() as keyof typeof Face;
+    const suffix = match[2];
+    let quarterTurns = 1;
+    if (suffix === "'") quarterTurns = -1;
+    if (suffix === '2') quarterTurns = 2;
+    moves.push({ face: Face[face], quarterTurns });
+  }
+
+  return moves;
+}
+
+export function handleIntent(intent: Intent, store: StoreLike) {
+  switch (intent.type) {
+    case 'mode/toggle':
+      store.toggleMode();
+      return;
+    case 'labels/cycle':
+      store.cycleLabelMode();
+      return;
+    case 'drop/cycle':
+      store.setDrop(
+        store.drop === 'none'
+          ? 'x'
+          : store.drop === 'x'
+          ? 'y'
+          : store.drop === 'y'
+          ? 'z'
+          : 'none'
+      );
+      return;
+    case 'drop/set':
+      store.setDrop(intent.axis);
+      return;
+    case 'slice/inc':
+      store.adjustSlice(intent.delta);
+      return;
+    case 'param/alpha':
+      store.adjustAlpha(intent.delta);
+      return;
+    case 'param/tau0':
+      store.adjustTau0(intent.delta);
+      return;
+    case 'potts/start':
+      if (store.isPottsRunning) {
+        store.stopPotts();
+      } else {
+        store.startPotts();
+      }
+      return;
+    case 'potts/stop':
+      store.stopPotts();
+      return;
+    case 'potts/reset':
+      store.resetPotts();
+      return;
+    case 'view/toggleAxes':
+      store.toggleShowAxes();
+      return;
+    case 'view/toggleLabels':
+      store.toggleShowLabels();
+      return;
+    case 'move':
+      store.applyMoveSequence(parseAlg(intent.seq));
+      return;
+    case 'ui/togglePalette':
+      store.setUi({ showPalette: intent.value ?? !store.ui.showPalette });
+      return;
+    case 'ui/toggleHelp':
+      store.setUi({ showHelp: intent.value ?? !store.ui.showHelp });
+      return;
+    default:
+      return;
+  }
+}

--- a/visualizer/src/input/intents.ts
+++ b/visualizer/src/input/intents.ts
@@ -1,0 +1,198 @@
+import type { Intent } from './gamepad';
+
+export const IntentNames = Object.freeze({
+  modeToggle: 'mode/toggle',
+  labelsCycle: 'labels/cycle',
+  dropNone: 'drop/set:none',
+  dropX: 'drop/set:x',
+  dropY: 'drop/set:y',
+  dropZ: 'drop/set:z',
+  dropCycle: 'drop/cycle',
+  sliceDecrease: 'slice/dec',
+  sliceIncrease: 'slice/inc',
+  alphaDecrease: 'param/alpha/dec',
+  alphaIncrease: 'param/alpha/inc',
+  tauDecrease: 'param/tau/dec',
+  tauIncrease: 'param/tau/inc',
+  toggleAxes: 'view/toggleAxes',
+  toggleLabels: 'view/toggleLabels',
+  pottsStart: 'potts/start',
+  pottsStop: 'potts/stop',
+  pottsReset: 'potts/reset',
+  openPalette: 'ui/togglePalette',
+  toggleHelp: 'ui/toggleHelp',
+} as const);
+
+export type IntentName = (typeof IntentNames)[keyof typeof IntentNames];
+
+export type IntentFactoryOptions = {
+  analogValue?: number;
+};
+
+export type IntentDefinition = {
+  id: string;
+  label: string;
+  category: string;
+  description?: string;
+  create: (options?: IntentFactoryOptions) => Intent;
+};
+
+export const IntentCatalog: Record<IntentName, IntentDefinition> = {
+  [IntentNames.modeToggle]: {
+    id: 'mode/toggle',
+    label: 'Toggle Color Mode',
+    category: 'Mode',
+    description: 'Switch between Exposure and Coupler modes',
+    create: () => ({ type: 'mode/toggle' }),
+  },
+  [IntentNames.labelsCycle]: {
+    id: 'labels/cycle',
+    label: 'Cycle Label Mode',
+    category: 'Mode',
+    create: () => ({ type: 'labels/cycle' }),
+  },
+  [IntentNames.dropNone]: {
+    id: 'drop/set:none',
+    label: 'Drop Axis: None',
+    category: 'Drop',
+    create: () => ({ type: 'drop/set', axis: 'none' }),
+  },
+  [IntentNames.dropX]: {
+    id: 'drop/set:x',
+    label: 'Drop Axis: X',
+    category: 'Drop',
+    create: () => ({ type: 'drop/set', axis: 'x' }),
+  },
+  [IntentNames.dropY]: {
+    id: 'drop/set:y',
+    label: 'Drop Axis: Y',
+    category: 'Drop',
+    create: () => ({ type: 'drop/set', axis: 'y' }),
+  },
+  [IntentNames.dropZ]: {
+    id: 'drop/set:z',
+    label: 'Drop Axis: Z',
+    category: 'Drop',
+    create: () => ({ type: 'drop/set', axis: 'z' }),
+  },
+  [IntentNames.dropCycle]: {
+    id: 'drop/cycle',
+    label: 'Cycle Drop Axis',
+    category: 'Drop',
+    create: () => ({ type: 'drop/cycle' }),
+  },
+  [IntentNames.sliceDecrease]: {
+    id: 'slice/dec',
+    label: 'Slice -1',
+    category: 'Slice',
+    create: () => ({ type: 'slice/inc', delta: -1 }),
+  },
+  [IntentNames.sliceIncrease]: {
+    id: 'slice/inc',
+    label: 'Slice +1',
+    category: 'Slice',
+    create: () => ({ type: 'slice/inc', delta: 1 }),
+  },
+  [IntentNames.alphaDecrease]: {
+    id: 'param/alpha/dec',
+    label: 'Alpha -',
+    category: 'Parameters',
+    create: ({ analogValue = 1 } = {}) => ({
+      type: 'param/alpha',
+      delta: -0.1 * analogValue,
+    }),
+  },
+  [IntentNames.alphaIncrease]: {
+    id: 'param/alpha/inc',
+    label: 'Alpha +',
+    category: 'Parameters',
+    create: ({ analogValue = 1 } = {}) => ({
+      type: 'param/alpha',
+      delta: 0.1 * analogValue,
+    }),
+  },
+  [IntentNames.tauDecrease]: {
+    id: 'param/tau/dec',
+    label: 'Tau₀ -',
+    category: 'Parameters',
+    create: ({ analogValue = 1 } = {}) => ({
+      type: 'param/tau0',
+      delta: -0.1 * analogValue,
+    }),
+  },
+  [IntentNames.tauIncrease]: {
+    id: 'param/tau/inc',
+    label: 'Tau₀ +',
+    category: 'Parameters',
+    create: ({ analogValue = 1 } = {}) => ({
+      type: 'param/tau0',
+      delta: 0.1 * analogValue,
+    }),
+  },
+  [IntentNames.toggleAxes]: {
+    id: 'view/toggleAxes',
+    label: 'Toggle Axes',
+    category: 'View',
+    create: () => ({ type: 'view/toggleAxes' }),
+  },
+  [IntentNames.toggleLabels]: {
+    id: 'view/toggleLabels',
+    label: 'Toggle Labels',
+    category: 'View',
+    create: () => ({ type: 'view/toggleLabels' }),
+  },
+  [IntentNames.pottsStart]: {
+    id: 'potts/start',
+    label: 'Start/Stop Potts',
+    category: 'Potts',
+    create: () => ({ type: 'potts/start' }),
+  },
+  [IntentNames.pottsStop]: {
+    id: 'potts/stop',
+    label: 'Stop Potts',
+    category: 'Potts',
+    create: () => ({ type: 'potts/stop' }),
+  },
+  [IntentNames.pottsReset]: {
+    id: 'potts/reset',
+    label: 'Reset Potts',
+    category: 'Potts',
+    create: () => ({ type: 'potts/reset' }),
+  },
+  [IntentNames.openPalette]: {
+    id: 'ui/togglePalette',
+    label: 'Open Command Palette',
+    category: 'UI',
+    create: () => ({ type: 'ui/togglePalette', value: true }),
+  },
+  [IntentNames.toggleHelp]: {
+    id: 'ui/toggleHelp',
+    label: 'Open Help',
+    category: 'UI',
+    create: () => ({ type: 'ui/toggleHelp', value: true }),
+  },
+};
+
+export const IntentGroups = ['Mode', 'Drop', 'Slice', 'Parameters', 'View', 'Potts', 'Moves', 'UI'];
+
+export function createIntentFromName(name: string, options?: IntentFactoryOptions): Intent | null {
+  const def = IntentCatalog[name];
+  if (!def) return null;
+  return def.create(options);
+}
+
+export type CommandEntry = {
+  id: string;
+  label: string;
+  category: string;
+  description?: string;
+};
+
+export function listCommandEntries(): CommandEntry[] {
+  return Object.values(IntentCatalog).map(({ id, label, category, description }) => ({
+    id,
+    label,
+    category,
+    description,
+  }));
+}


### PR DESCRIPTION
## Summary
- rebuild the visualizer shell with a compact app bar, collapsible left dock, status bar, command palette, help overlay, HUD, and settings modal tailored for controller-first navigation
- extend the store with persistent controller/UI configuration and wire a new intent catalog plus gamepad polling hook to translate button presses into semantic actions
- surface controller activity and command bindings through dedicated HUD, help, and settings interfaces while keeping the cube scene intact

## Testing
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68cd19222cac832e82d255629db21de1